### PR TITLE
feat: support packaging vsix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # semantic-release-vsce
 
-[![Build Status](https://travis-ci.org/raix/semantic-release-vsce.svg?branch=master)](https://travis-ci.org/raix/semantic-release-vsce)
-[![Greenkeeper badge](https://badges.greenkeeper.io/raix/semantic-release-vsce.svg)](https://greenkeeper.io/)
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
+[![Build Status](https://travis-ci.org/raix/semantic-release-vsce.svg?branch=master)](https://travis-ci.org/raix/semantic-release-vsce) [![Greenkeeper badge](https://badges.greenkeeper.io/raix/semantic-release-vsce.svg)](https://greenkeeper.io/) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 Semantic release plugin for vs code extensions
 
@@ -13,58 +11,56 @@ NOTE: This package is still experimental - `semantic-release` multi plugins are 
 ```json
 {
   "scripts": {
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release"
   },
   "release": {
-    "verifyConditions": [
-      "@semantic-release/travis",
-      "semantic-release-vsce",
-      "@semantic-release/github"
-    ],
+    "verifyConditions": ["semantic-release-vsce", "@semantic-release/github"],
     "getLastRelease": "semantic-release-vsce",
-    "analyzeCommits": "@semantic-release/conventional-changelog",
-    "verifyRelease": [
-      "@semantic-release/lts"
-    ],
-    "generateNotes" : "@semantic-release/conventional-changelog",
     "publish": [
-      "semantic-release-vsce",
-      "@semantic-release/github"
+      {
+        "path": "semantic-release-vsce",
+        "packageVsix": "your-extension.vsix"
+      },
+      {
+        "path": "@semantic-release/github",
+        "assets": "your-extension.vsix"
+      }
     ]
   },
   "devDependencies": {
-    "semantic-release": "x.x.x"
+    "semantic-release": "^10.0.0"
   }
 }
 ```
 
+If `packageVsix` is set, will also generate a .vsix file at the set file path after publishing.
+It is recommended to upload this to your GitHub release page so your users can easily rollback to an earlier version if a version ever introduces a bad bug. 
+
 #### Travis example
 
-Environment variables:
-```
-  VSCE_TOKEN=""
-```
+Secret environment variables: `VSCE_TOKEN`
 
 Example:
+
 ```yaml
 # .travis.yml
-language: node_js
+
 cache:
   directories:
     - ~/.npm
-    - "node_modules"
-node_js:
-  - '8'
-install:
-  - npm install
-stages:
-  - test
-  - name: publish
-    if: brance = master
+
 script:
   - npm test
+
+stages:
+  - test
+  - name: release
+    if: branch = master AND type = push AND fork = false
+
 jobs:
   include:
-    - stage: publish
-    - script: npm run semantic-release
+    - stage: release
+      language: node_js
+      node_js: '8'
+      script: npm run semantic-release
 ```

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ async function publish (pluginConfig, {pkg, nextRelease: {version}, logger}) {
     await verifyVsce(pkg, logger);
     verified = true;
   }
-  await vscePublish(version, logger);
+  await vscePublish(version, pluginConfig.packageVsix, logger);
 }
 
 module.exports = {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,12 +1,16 @@
 const execa = require('execa');
 const updatePackageVersion = require('./update-package-version');
 
-module.exports = async (version, logger) => {
+module.exports = async (pluginConfig, packageVsix, logger) => {
   const { VSCE_TOKEN } = process.env;
 
   await updatePackageVersion(version, logger);
 
   logger.log('Publishing version %s to vs code marketplace', version);
-  const shell = await execa('vsce', ['publish', '-t', VSCE_TOKEN]);
-  process.stdout.write(shell.stdout);
+  await execa('vsce', ['publish', '-t', VSCE_TOKEN], { stdio: 'inherit'});
+  
+  if (packageVsix) {
+    logger.log('Packaging version %s as .vsix', version);
+    await exaca('vsce', ['package', '--out', packageVsix], { stdio: 'inherit' });
+  }
 };

--- a/lib/verify-pkg.js
+++ b/lib/verify-pkg.js
@@ -5,6 +5,6 @@ module.exports = ({name, publisher}) => {
     throw new SemanticReleaseError('No "name" found in package.json.', 'ENOPKGNAME');
   }
   if (!publisher) {
-    throw new SemanticReleaseError('No "publisher" found in package.json.', 'ENOPKGNAME');
+    throw new SemanticReleaseError('No "publisher" found in package.json.', 'ENOPUBLISHER');
   }
 };


### PR DESCRIPTION
Uploading a vsix to the GitHub release is very helpful when a version ever gets a bug so users can easily rollback.
We need to package this inside the plugin because the package version needs to be written into package.json before we can package it, and we want to publish it afterwards with the github publish plugin.

I updated the README to remove things from the config that were just repeating the default values of semantic-release and added this option to the example (I believe every extension should do this). I removed `condition-travis` because it doesn't work / is not needed with build stages.

I also corrected the .travis.yml example - it was partly invalid and partly dangerous, for example the release happened on every PR too. I tried to make the `release` job as isolated as possible (specifying the Node version in there) to make it easy to drop _just_ the release-stage into a travis config that possibly doesn't even use NodeJS as the main language. Also removed `node_modules` from the cache because that doesn't work if you have native modules between different jobs with different Node versions. Just caching the npm cache is sufficient.

Btw, is there a reason you don't use prettier like the semantic-release extensions?