### PR TITLE
feat: update to semantic-release v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![downloads](https://img.shields.io/npm/dt/semantic-release-vsce.svg)](https://www.npmjs.com/package/semantic-release-vsce)
 [![build](https://travis-ci.org/raix/semantic-release-vsce.svg?branch=master)](https://travis-ci.org/raix/semantic-release-vsce)
 [![dependencies](https://david-dm.org/raix/semantic-release-vsce/status.svg)](https://david-dm.org/raix/semantic-release-vsce)
+[![peerDependencies](https://david-dm.org/raix/semantic-release-vsce/peer-status.svg)](https://david-dm.org/raix/semantic-release-vsce?type=peer)
 [![Greenkeeper](https://badges.greenkeeper.io/raix/semantic-release-vsce.svg)](https://greenkeeper.io/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ NOTE: This package is still experimental - `semantic-release` multi plugins are 
     ]
   },
   "devDependencies": {
-    "semantic-release": "^10.0.0"
+    "semantic-release": "^11.0.0"
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,33 +1,32 @@
-const {callbackify} = require('util');
 const verifyVsce = require('./lib/verify');
 const vscePublish = require('./lib/publish');
 const getLastReleaseGallery = require('./lib/get-last-release');
 
 let verified;
 
-async function verifyConditions (pluginConfig, {pkg, logger}) {
-  await verifyVsce(pkg, logger);
+async function verifyConditions (pluginConfig, {logger}) {
+  await verifyVsce(logger);
   verified = true;
 }
 
-async function getLastRelease (pluginConfig, {pkg, logger}) {
+async function getLastRelease (pluginConfig, {logger}) {
   if (!verified) {
-    await verifyVsce(pkg, logger);
+    await verifyVsce(logger);
     verified = true;
   }
-  return getLastReleaseGallery(pkg, logger);
+  return getLastReleaseGallery(logger);
 }
 
-async function publish (pluginConfig, {pkg, nextRelease: {version}, logger}) {
+async function publish (pluginConfig, {nextRelease: {version}, logger}) {
   if (!verified) {
-    await verifyVsce(pkg, logger);
+    await verifyVsce(logger);
     verified = true;
   }
   await vscePublish(version, pluginConfig.packageVsix, logger);
 }
 
 module.exports = {
-  verifyConditions: callbackify(verifyConditions),
-  getLastRelease: callbackify(getLastRelease),
-  publish: callbackify(publish)
+  verifyConditions,
+  getLastRelease,
+  publish
 };

--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -1,5 +1,6 @@
 const fetch = require('node-fetch');
 const semver = require('semver');
+const getPkg = require('read-pkg-up');
 const registry = 'vs code marketplace';
 
 /**
@@ -8,7 +9,8 @@ const registry = 'vs code marketplace';
   * https://github.com/Microsoft/vscode/blob/b00945fc8c79f6db74b280ef53eba060ed9a1388/product.json#L17-L21
 */
 
-module.exports = async ({publishConfig, name, publisher}, logger) => {
+module.exports = async (logger) => {
+  const {pkg: {name, publisher}} = await getPkg();
   const extensionId = `${publisher}.${name}`;
   logger.log(`Lookup extension details for "${extensionId}".`);
   const body = JSON.stringify({

--- a/lib/set-auth.js
+++ b/lib/set-auth.js
@@ -1,6 +1,6 @@
 const SemanticReleaseError = require('@semantic-release/error');
 
-module.exports = async ({publishConfig, name}, logger) => {
+module.exports = async (logger) => {
   logger.log('Verify authentication for vsce');
   const {VSCE_TOKEN} = process.env;
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,10 +1,15 @@
 const verifyPkg = require('./verify-pkg');
 const setAuth = require('./set-auth');
+const getPkg = require('read-pkg-up');
 const SemanticReleaseError = require('@semantic-release/error');
 
-module.exports = async (pkg, logger) => {
+module.exports = async (logger) => {
+  const {pkg} = await getPkg();
+  if (!pkg) {
+    throw new SemanticReleaseError('package.json not found. A package.json is required to release with vsce.', 'ENOPKG');
+  }
   verifyPkg(pkg);
-  await setAuth(pkg, logger);
+  await setAuth(logger);
   try {
     // TODO: Verify output
   } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@semantic-release/commit-analyzer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-4.0.0.tgz",
-      "integrity": "sha512-dbKryDrlOVfWycRbMOPRwMQHbabrzME2lFIIWAw8/gcDUYlNBhlqYuwbw+Wp1/ABAJnQTPo5dfMBEX9Q6pPCwQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-5.0.0.tgz",
+      "integrity": "sha512-DWqE0EwLfqawNzH/cPd987KyplsvwmlKTr6Oz/hPe2NuIwexD8Zt7EvBvHt35udcRsK0EK6+QZTIz06Fr/gIsg==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.5.2",
@@ -18,15 +18,14 @@
       }
     },
     "@semantic-release/condition-travis": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-6.1.1.tgz",
-      "integrity": "sha512-t52gG3VAIgNnWEFMfayRafZjfgERq0uxMsgMGSCSxBrX2DwJozo6Oel8N58GMURMH9APaU6caoC6nlZNgKy3kA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/condition-travis/-/condition-travis-7.0.0.tgz",
+      "integrity": "sha512-uXfK1P7qXf9WqbLJZGmtW2yy8Qu6nJ+o+hbOJt1apqr2tl7C8t7ticiB1sEID+uCxKw/uaUxfJYkA0z9pqCcEw==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "2.1.0",
-        "github": "12.0.2",
-        "parse-github-repo-url": "1.4.1",
-        "semver": "5.4.1",
+        "github": "12.0.5",
+        "parse-github-url": "1.0.1",
         "travis-deploy-once": "3.0.0"
       }
     },
@@ -36,48 +35,23 @@
       "integrity": "sha512-r3pcw7lhzoSalM55O7L8R3gNq8AnZ7OS7RReHqJDTIuyRaQbtfZ+9S8Krvh/BSnTMYYhs4TgZctb6pOamegUtQ=="
     },
     "@semantic-release/github": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-1.0.0.tgz",
-      "integrity": "sha512-Rofz+v4y/dUm1jMOPjG3c/z44uiOVjdSH+PYb0DJbCsTYBiDI3YGmyIrvR/g2LeoA43deOPjIovqqp2So+TzLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-2.0.0.tgz",
+      "integrity": "sha512-LFKiBdiebHN6VAwsU7WFKoOFggszPzRN+zFp/WD2UvFmLJuxB9X1bcRCTXoUDXuo49rkV8nvPk2THs5VUHOmFA==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "2.1.0",
         "debug": "3.1.0",
         "fs-extra": "4.0.2",
-        "git-url-parse": "7.0.1",
         "github": "12.0.5",
-        "p-each-series": "1.0.0"
-      },
-      "dependencies": {
-        "follow-redirects": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
-          "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0"
-          }
-        },
-        "github": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/github/-/github-12.0.5.tgz",
-          "integrity": "sha512-4U81TDODHt6RcbuRGwKYmdCmiV4PfnR0NWRIyiZdBoYYGZCRav+KiL45XMueJW8EU5FBiZ2Ox9RoPz1iQUmlJQ==",
-          "dev": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "follow-redirects": "1.2.6",
-            "https-proxy-agent": "2.1.0",
-            "lodash": "4.17.4",
-            "mime": "2.0.3",
-            "netrc": "0.1.4"
-          }
-        }
+        "p-each-series": "1.0.0",
+        "parse-github-url": "1.0.1"
       }
     },
     "@semantic-release/npm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-1.0.0.tgz",
-      "integrity": "sha512-BRSAildRf6ZnQ0LdwACSPsWWcxeMFEoGVitbLO1yorXHfN4K+Nn3P0OT+ZuRRYB8rRdTEdn5JMieW0I9WqDS4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-2.0.0.tgz",
+      "integrity": "sha512-4MaW4HqE2Wi1rP8dBELmGUAeSeUM8/rHGbX9/UUQ4EHnAQNxBw6kNAlBMH1ZqweHQN0DSV8aA6JeTSOjiqMxuA==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "2.1.0",
@@ -86,13 +60,14 @@
         "nerf-dart": "1.0.0",
         "npm-conf": "1.1.3",
         "npm-registry-client": "8.5.0",
+        "read-pkg-up": "3.0.0",
         "registry-auth-token": "3.3.1"
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-5.0.2.tgz",
-      "integrity": "sha512-NM4cwgUlvPuo1M48ejFcsnQSYLZWE3anhKGS/lYFx+UxPnVUSJCjHcpWUZUC9Sy4WToPMDpSNN2HdT1STiCmlQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-6.0.0.tgz",
+      "integrity": "sha512-f6LzViBn3W/YELTLIQfE+SygzuTy+/AoK2zPFC0wCUFW9lPz9v1WRYZNYrzn9iwGN0QWtNvE0P0hdRO0mg4SKw==",
       "dev": true,
       "requires": {
         "conventional-changelog-angular": "1.5.2",
@@ -100,7 +75,7 @@
         "conventional-commits-parser": "2.0.1",
         "debug": "3.1.0",
         "get-stream": "3.0.0",
-        "hosted-git-info": "2.5.0",
+        "git-url-parse": "7.0.1",
         "import-from": "2.1.0",
         "into-stream": "3.1.0",
         "lodash": "4.17.4"
@@ -142,9 +117,9 @@
       }
     },
     "agent-base": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
-      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.2.tgz",
+      "integrity": "sha512-VE6QoEdaugY86BohRtfGmTDabxdU5sCKOkbcPA6PXKJsRzEi/7A3RCTxJal1ft/4qSfPht5/iQLhMh/wzSkkNw==",
       "dev": true,
       "requires": {
         "es6-promisify": "5.0.0"
@@ -636,7 +611,7 @@
       "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
       "dev": true,
       "requires": {
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "proto-list": "1.2.4"
       }
     },
@@ -708,6 +683,29 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "cross-spawn": {
       "version": "5.1.0",
@@ -1079,6 +1077,52 @@
             "esutils": "2.0.2",
             "isarray": "1.0.0"
           }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
         }
       }
     },
@@ -1257,23 +1301,12 @@
       }
     },
     "follow-redirects": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz",
-      "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz",
+      "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "debug": "3.1.0"
       }
     },
     "forever-agent": {
@@ -1466,13 +1499,13 @@
       }
     },
     "github": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/github/-/github-12.0.2.tgz",
-      "integrity": "sha512-BRbdRpEk57frirtD7vDnMIYcIVkBl8ctVD9eY9tRI0kS1Dnk6OkP0ZmLQ+H4+2aOp1MsCy/q2+Tzj1PrBzrJpw==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/github/-/github-12.0.5.tgz",
+      "integrity": "sha512-4U81TDODHt6RcbuRGwKYmdCmiV4PfnR0NWRIyiZdBoYYGZCRav+KiL45XMueJW8EU5FBiZ2Ox9RoPz1iQUmlJQ==",
       "dev": true,
       "requires": {
         "dotenv": "4.0.0",
-        "follow-redirects": "1.2.5",
+        "follow-redirects": "1.2.6",
         "https-proxy-agent": "2.1.0",
         "lodash": "4.17.4",
         "mime": "2.0.3",
@@ -1652,7 +1685,7 @@
       "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.1.1",
+        "agent-base": "4.1.2",
         "debug": "2.6.9"
       },
       "dependencies": {
@@ -1723,9 +1756,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -1777,6 +1810,12 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -1933,6 +1972,11 @@
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -2029,14 +2073,30 @@
       }
     },
     "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "requires": {
         "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
         "strip-bom": "3.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "locate-path": {
@@ -2572,10 +2632,10 @@
         "retry": "0.10.1"
       }
     },
-    "parse-github-repo-url": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
+    "parse-github-url": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.1.tgz",
+      "integrity": "sha512-w7N3anrhTV0kUoUp2reEY8716DScD/Z958QZm6E7VbqzoPs6TnbWFrBBHUzgpxcBoKFkFh3NQ0AS6rxIIKH+fQ==",
       "dev": true
     },
     "parse-json": {
@@ -2641,11 +2701,18 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
       }
     },
     "pend": {
@@ -2740,7 +2807,7 @@
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -2762,22 +2829,22 @@
       }
     },
     "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "requires": {
-        "load-json-file": "2.0.0",
+        "load-json-file": "4.0.0",
         "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
       "requires": {
         "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "read-pkg": "3.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -2885,6 +2952,12 @@
         "tunnel-agent": "0.4.3"
       }
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -2967,30 +3040,30 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semantic-release": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-10.0.0.tgz",
-      "integrity": "sha512-ioP0k+thumaE85/84dy1ajYHTT6jdvzXuTtNwi9Z04bheDG8DGB1rJdm6dXkZ6mhnoqIqj/9oY6Pi4z1bDed7A==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-11.0.0.tgz",
+      "integrity": "sha512-PmBEqJQwmmLPBTHGAjqxONFbd7M1k54M07FOfbtLcWO/88d36kyUNPehu5RLPsfptmQi1BBjx1h5xBw/F4DLhg==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "4.0.0",
-        "@semantic-release/condition-travis": "6.1.1",
+        "@semantic-release/commit-analyzer": "5.0.0",
+        "@semantic-release/condition-travis": "7.0.0",
         "@semantic-release/error": "2.1.0",
-        "@semantic-release/github": "1.0.0",
-        "@semantic-release/npm": "1.0.0",
-        "@semantic-release/release-notes-generator": "5.0.2",
+        "@semantic-release/github": "2.0.0",
+        "@semantic-release/npm": "2.0.0",
+        "@semantic-release/release-notes-generator": "6.0.0",
         "chalk": "2.3.0",
         "commander": "2.11.0",
+        "cosmiconfig": "3.1.0",
         "debug": "3.1.0",
         "execa": "0.8.0",
-        "fs-extra": "4.0.2",
         "get-stream": "3.0.0",
         "git-log-parser": "1.2.0",
         "import-from": "2.1.0",
         "lodash": "4.17.4",
         "marked": "0.3.6",
         "marked-terminal": "2.0.0",
-        "normalize-package-data": "2.4.0",
         "p-reduce": "1.0.0",
+        "read-pkg-up": "3.0.0",
         "semver": "5.4.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,11 +26,15 @@
     "execa": "^0.8.0",
     "fs-extra": "^4.0.2",
     "node-fetch": "^1.7.3",
+    "read-pkg-up": "^3.0.0",
     "semver": "^5.4.1",
     "vsce": "^1.33.2"
   },
   "devDependencies": {
-    "semantic-release": "^10.0.0"
+    "semantic-release": "^11.0.0"
+  },
+  "peerDependencies": {
+    "semantic-release": "^11.0.0"
   },
   "release": {
     "verifyConditions": "@semantic-release/github"


### PR DESCRIPTION
Return promises from plugins
Don't rely on pkg being passed, read it with read-pkg-up.

BREAKING CHANGE:
Requires semantic-release v11.

--------------
Basically did what @semantic-release/npm did.
This will release 1.0.0.
Not really tested so please review carefully.