### PR TITLE
feat: support using VSCE_PAT environment variable for authentication token

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Prior to v13, you had to override `getLastRelease` to use `@semantic-release/git
 
 #### Travis example
 
-Secret environment variables: `VSCE_TOKEN`
+Secret environment variables: `VSCE_PAT`
 
 Example:
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,13 +2,17 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 
 module.exports = async (version, yarn, logger) => {
-  const { VSCE_TOKEN } = process.env;
+  const { VSCE_TOKEN, VSCE_PAT } = process.env;
 
   const { publisher, name } = await readJson('./package.json');
 
   logger.log('Publishing version %s to vs code marketplace', version);
 
-  const options = ['publish', '--pat', VSCE_TOKEN];
+  const options = ['publish'];
+
+  if (!VSCE_PAT && VSCE_TOKEN) {
+    options.push('--pat', VSCE_TOKEN);
+  }
 
   if (yarn) {
     options.push('--yarn');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,17 +2,11 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 
 module.exports = async (version, yarn, logger) => {
-  const { VSCE_TOKEN, VSCE_PAT } = process.env;
-
   const { publisher, name } = await readJson('./package.json');
 
   logger.log('Publishing version %s to vs code marketplace', version);
 
   const options = ['publish'];
-
-  if (!VSCE_PAT && VSCE_TOKEN) {
-    options.push('--pat', VSCE_TOKEN);
-  }
 
   if (yarn) {
     options.push('--yarn');

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -3,14 +3,18 @@ const SemanticReleaseError = require('@semantic-release/error');
 
 module.exports = async (logger) => {
   logger.log('Verify authentication for vsce');
-  const { VSCE_TOKEN } = process.env;
+  const { VSCE_TOKEN, VSCE_PAT } = process.env;
 
-  if (!VSCE_TOKEN) {
-    throw new SemanticReleaseError('No vsce personal access token specified (set the "VSCE_TOKEN" environment variable).', 'ENOVSCEPAT');
+  if (!VSCE_TOKEN && !VSCE_PAT) {
+    throw new SemanticReleaseError('No vsce personal access token specified (set the "VSCE_PAT" environment variable).', 'ENOVSCEPAT');
   }
 
   try {
-    execa.sync('vsce', ['verify-pat', '--pat', VSCE_TOKEN]);
+    const options = ['verify-pat'];
+    if (VSCE_TOKEN) {
+      options.push('--pat', VSCE_TOKEN);
+    }
+    execa.sync('vsce', options);
   } catch (e) {
     throw new SemanticReleaseError(`Invalid vsce token. Additional information:\n\n${e}`, 'EINVALIDVSCETOKEN');
   }

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -3,17 +3,18 @@ const SemanticReleaseError = require('@semantic-release/error');
 
 module.exports = async (logger) => {
   logger.log('Verify authentication for vsce');
-  const { VSCE_TOKEN, VSCE_PAT } = process.env;
 
-  if (!VSCE_TOKEN && !VSCE_PAT) {
+  if (!('VSCE_PAT' in process.env) && ('VSCE_TOKEN' in process.env)) {
+    logger.log('VSCE_TOKEN is deprecated and may be removed in the next major release, please use VSCE_PAT instead.');
+    process.env.VSCE_PAT = process.env.VSCE_TOKEN;
+  }
+
+  if (!process.env.VSCE_PAT) {
     throw new SemanticReleaseError('No vsce personal access token specified (set the "VSCE_PAT" environment variable).', 'ENOVSCEPAT');
   }
 
   try {
     const options = ['verify-pat'];
-    if (VSCE_TOKEN) {
-      options.push('--pat', VSCE_TOKEN);
-    }
     execa.sync('vsce', options);
   } catch (e) {
     throw new SemanticReleaseError(`Invalid vsce token. Additional information:\n\n${e}`, 'EINVALIDVSCETOKEN');

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -66,3 +66,29 @@ test('publish when yarn is true', async t => {
   });
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--pat', token, '--yarn'], { stdio: 'inherit' }]);
 });
+
+test('publish with VSCE_PAT and VSCE_TOKEN should prefer VSCE_PAT', async t => {
+  const { execaStub } = t.context.stubs;
+  const publisher = 'semantic-release-vsce';
+  const name = 'Semantice Release VSCE';
+  const publish = proxyquire('../lib/publish', {
+    execa: execaStub,
+    'fs-extra': {
+      readJson: sinon.stub().returns({
+        publisher,
+        name
+      })
+    }
+  });
+
+  const token = 'abc123';
+  process.env.VSCE_TOKEN = token;
+  process.env.VSCE_PAT = token;
+  const result = await publish('1.0.0', undefined, logger);
+
+  t.deepEqual(result, {
+    name: 'Visual Studio Marketplace',
+    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
+  });
+  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish'], { stdio: 'inherit' }]);
+});

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -38,7 +38,7 @@ test('publish', async t => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
   });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--pat', token], { stdio: 'inherit' }]);
+  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish'], { stdio: 'inherit' }]);
 });
 
 test('publish when yarn is true', async t => {
@@ -64,7 +64,7 @@ test('publish when yarn is true', async t => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
   });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--pat', token, '--yarn'], { stdio: 'inherit' }]);
+  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--yarn'], { stdio: 'inherit' }]);
 });
 
 test('publish with VSCE_PAT and VSCE_TOKEN should prefer VSCE_PAT', async t => {

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -22,6 +22,19 @@ test('VSCE_TOKEN is not set', async t => {
   await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
 });
 
+test('VSCE_PAT is set', async t => {
+  process.env.VSCE_PAT = 'abc123';
+
+  await t.notThrowsAsync(() => verifyAuth(logger));
+});
+
+test('VSCE_PAT is not set', async t => {
+  delete process.env.VSCE_TOKEN;
+  delete process.env.VSCE_PAT;
+
+  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
+});
+
 test('VSCE_TOKEN is valid', async t => {
   process.env.VSCE_TOKEN = 'abc123';
 
@@ -30,6 +43,20 @@ test('VSCE_TOKEN is valid', async t => {
 
 test('VSCE_TOKEN is invalid', async t => {
   process.env.VSCE_TOKEN = 'abc123';
+  execa.sync.restore();
+
+  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'EINVALIDVSCETOKEN' });
+});
+
+test('VSCE_PAT is valid', async t => {
+  process.env.VSCE_PAT = 'abc123';
+  sinon.stub(execa, 'sync').withArgs('vsce', ['verify-pat']).returns();
+
+  await t.notThrowsAsync(() => verifyAuth(logger));
+});
+
+test('VSCE_PAT is invalid', async t => {
+  process.env.VSCE_PAT = 'abc123';
   execa.sync.restore();
 
   await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'EINVALIDVSCETOKEN' });

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -18,6 +18,7 @@ test('VSCE_TOKEN is set', async t => {
 
 test('VSCE_TOKEN is not set', async t => {
   delete process.env.VSCE_TOKEN;
+  delete process.env.VSCE_PAT;
 
   await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
 });


### PR DESCRIPTION
This adds support for using the VSCE_PAT environment variable supported in vsce, if both VSCE_PAT
and VSCE_TOKEN are set in the environment then VSCE_PAT is preferred. It might be worthwhile to also
introduce a log that inform the user this is happening and to only use VSCE_PAT

Closes #84