### PR TITLE
build(deps): drop support for Node 10 and 12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10
-          - 12
           - 14
+          - 16
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "sinon": "^11.1.1"
       },
       "engines": {
-        "node": ">=10.18"
+        "node": ">=14"
       },
       "peerDependencies": {
         "semantic-release": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "semantic-release plugin to package and publish VS Code extensions",
   "license": "MIT",
   "engines": {
-    "node": ">=10.18"
+    "node": ">=14"
   },
   "repository": "https://github.com/felipecrs/semantic-release-vsce.git",
   "bugs": "https://github.com/felipecrs/semantic-release-vsce/issues",
@@ -48,8 +48,8 @@
     "preset": "conventionalcommits"
   },
   "volta": {
-    "node": "14.17.6",
-    "npm": "7.23.0"
+    "node": "16.13.2",
+    "npm": "8.3.1"
   },
   "dependencies": {
     "@semantic-release/error": "^2.2.0",


### PR DESCRIPTION
And set Node 16 as the default.

BREAKING CHANGE: This drops support for Node 10 and 12 because `vsce`
itself also did. Make sure your pipeline now runs in an environment with
Node 14 or higher.
