### PR TITLE
build(deps-dev): remove eslint-plugin-standard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "eslint-plugin-import": "^2.20.1",
         "eslint-plugin-node": "^11.0.0",
         "eslint-plugin-promise": "^5.1.0",
-        "eslint-plugin-standard": "^5.0.0",
         "husky": "^6.0.0",
         "nyc": "^15.1.0",
         "proxyquire": "^2.1.3",
@@ -3416,30 +3415,6 @@
       },
       "peerDependencies": {
         "eslint": "^7.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
-      "deprecated": "standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -15122,13 +15097,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz",
       "integrity": "sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-standard": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-5.0.0.tgz",
-      "integrity": "sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-standard": "^5.0.0",
     "husky": "^6.0.0",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
As it's not needed anymore according to
https://www.npmjs.com/package/eslint-plugin-standard.