### PR TITLE
build(deps-dev): bump semantic-release from v18 to v19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "husky": "^7.0.4",
         "nyc": "^15.1.0",
         "proxyquire": "^2.1.3",
-        "semantic-release": "^18.0.1",
+        "semantic-release": "^19.0.2",
         "sinon": "^12.0.1"
       },
       "engines": {
@@ -1135,9 +1135,9 @@
       "dev": true
     },
     "node_modules/@semantic-release/npm": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
+      "integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
@@ -1147,7 +1147,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -1155,10 +1155,10 @@
         "tempy": "^1.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16 || ^14.17"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0"
+        "semantic-release": ">=19.0.0"
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
@@ -1362,24 +1362,24 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "type-fest": "^1.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -2269,16 +2269,19 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+    "node_modules/cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
-        "colors": "1.0.3"
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">= 0.2.0"
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-truncate": {
@@ -2398,10 +2401,11 @@
       "dev": true
     },
     "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -5527,12 +5531,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -5625,32 +5623,47 @@
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/marked-terminal": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
-      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.0.0.tgz",
+      "integrity": "sha512-26604GmGmW63ElxcXpE2xfMdbtgD/qiwIqOh/+5+uPe6NVU4bU433+wvPTfq6NZcGr16KWqwu/dzsKxg3IL2Xw==",
       "dev": true,
       "dependencies": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table": "^0.3.1",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.0",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "engines": {
+        "node": " >=14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0"
+        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+      "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/matcher": {
@@ -5955,12 +5968,12 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node_modules/node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "dependencies": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/node-fetch": {
@@ -6047,9 +6060,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.3.1.tgz",
+      "integrity": "sha512-f552vKhT3r+PpCRnH7UferrrbcnvcFnGusN2T1mQqq/0UQd3pF1+ok4n0WahT0ZKxj10YU3b2VdhGrf39djHAA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -6106,6 +6119,7 @@
         "opener",
         "pacote",
         "parse-conflict-json",
+        "proc-log",
         "qrcode-terminal",
         "read",
         "read-package-json",
@@ -6179,6 +6193,7 @@
         "opener": "*",
         "pacote": "*",
         "parse-conflict-json": "*",
+        "proc-log": "*",
         "qrcode-terminal": "*",
         "read": "*",
         "read-package-json": "*",
@@ -6200,7 +6215,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm-run-path": {
@@ -6227,21 +6242,21 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.9.0",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@isaacs/string-locale-compare": "^1.0.1",
+        "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/installed-package-contents": "^1.0.7",
-        "@npmcli/map-workspaces": "^1.0.2",
-        "@npmcli/metavuln-calculator": "^1.1.0",
+        "@npmcli/map-workspaces": "^2.0.0",
+        "@npmcli/metavuln-calculator": "^2.0.0",
         "@npmcli/move-file": "^1.1.0",
         "@npmcli/name-from-folder": "^1.0.1",
-        "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/node-gyp": "^1.0.3",
         "@npmcli/package-json": "^1.0.1",
-        "@npmcli/run-script": "^1.8.2",
-        "bin-links": "^2.2.1",
+        "@npmcli/run-script": "^2.0.0",
+        "bin-links": "^2.3.0",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
@@ -6252,8 +6267,8 @@
         "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.3.5",
-        "parse-conflict-json": "^1.1.1",
+        "pacote": "^12.0.2",
+        "parse-conflict-json": "^2.0.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.1",
@@ -6269,17 +6284,17 @@
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": ">= 10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/ci-detect": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6349,7 +6364,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.4",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6360,18 +6375,22 @@
         "read-package-json-fast": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "1.1.1",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cacache": "^15.0.5",
-        "pacote": "^11.1.11",
+        "json-parse-even-better-errors": "^2.3.1",
+        "pacote": "^12.0.0",
         "semver": "^7.3.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/move-file": {
@@ -6394,7 +6413,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -6418,14 +6437,14 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.6",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "node-gyp": "^7.1.0",
+        "node-gyp": "^8.2.0",
         "read-package-json-fast": "^2.0.1"
       }
     },
@@ -6457,7 +6476,7 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.1.4",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6481,22 +6500,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
@@ -6548,7 +6551,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.6",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6566,68 +6569,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/asn1": {
-      "version": "0.2.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/assert-plus": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/npm/node_modules/asynckit": {
-      "version": "0.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/aws4": {
-      "version": "1.11.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "2.2.1",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^4.0.1",
-        "mkdirp": "^1.0.3",
+        "mkdirp-infer-owner": "^2.0.0",
         "npm-normalize-package-bin": "^1.0.0",
         "read-cmd-shim": "^2.0.0",
         "rimraf": "^3.0.0",
@@ -6691,12 +6646,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/caseless": {
-      "version": "0.12.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/npm/node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -6744,16 +6693,60 @@
       }
     },
     "node_modules/npm/node_modules/cli-columns": {
-      "version": "3.1.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "string-width": "^2.0.0",
-        "strip-ansi": "^3.0.1"
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
@@ -6837,15 +6830,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/npm/node_modules/code-point-at": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -6893,18 +6877,6 @@
         "wcwidth": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/combined-stream": {
-      "version": "1.0.8",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
@@ -6922,24 +6894,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/dashdash": {
-      "version": "1.14.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.2",
@@ -6982,15 +6936,6 @@
         "clone": "^1.0.2"
       }
     },
-    "node_modules/npm/node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/npm/node_modules/delegates": {
       "version": "1.0.0",
       "dev": true,
@@ -7025,16 +6970,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
       "dev": true,
@@ -7066,47 +7001,11 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/extend": {
-      "version": "3.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/extsprintf": {
-      "version": "1.3.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/forever-agent": {
-      "version": "0.6.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "2.1.0",
@@ -7133,32 +7032,67 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "ansi-regex": "^5.0.1",
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
         "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1 || ^2.0.0",
-        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
-    "node_modules/npm/node_modules/getpass": {
-      "version": "0.1.7",
+    "node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "assert-plus": "^1.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/glob": {
@@ -7186,28 +7120,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/har-schema": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/npm/node_modules/har-validator": {
-      "version": "5.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/npm/node_modules/has": {
       "version": "1.0.3",
@@ -7237,7 +7149,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "4.0.2",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7266,21 +7178,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/http-signature": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
@@ -7319,12 +7216,15 @@
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "3.0.4",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -7422,7 +7322,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.7.0",
+      "version": "2.8.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7460,31 +7360,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/isstream": {
-      "version": "0.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/jsbn": {
-      "version": "0.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/json-schema": {
-      "version": "0.2.3",
-      "dev": true,
-      "inBundle": true
-    },
-    "node_modules/npm/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
@@ -7498,12 +7375,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
       "dev": true,
@@ -7513,35 +7384,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/jsprim": {
-      "version": "1.4.1",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "3.1.1",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "3.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "4.0.3",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7552,11 +7408,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "2.0.4",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7567,46 +7423,49 @@
         "diff": "^5.0.0",
         "minimatch": "^3.0.4",
         "npm-package-arg": "^8.1.4",
-        "pacote": "^11.3.4",
+        "pacote": "^12.0.0",
         "tar": "^6.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.1",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.3.0",
+        "@npmcli/arborist": "^4.0.0",
         "@npmcli/ci-detect": "^1.3.0",
-        "@npmcli/run-script": "^1.8.4",
+        "@npmcli/run-script": "^2.0.0",
         "chalk": "^4.1.0",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-package-arg": "^8.1.2",
-        "pacote": "^11.3.1",
+        "pacote": "^12.0.0",
         "proc-log": "^1.0.0",
         "read": "^1.0.7",
         "read-package-json-fast": "^2.0.2",
         "walk-up-path": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "1.1.0",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^2.5.0"
+        "@npmcli/arborist": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "6.0.3",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7615,11 +7474,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "2.0.3",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7628,25 +7487,25 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "2.0.1",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/run-script": "^1.8.3",
+        "@npmcli/run-script": "^2.0.0",
         "npm-package-arg": "^8.1.0",
-        "pacote": "^11.2.6"
+        "pacote": "^12.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "4.0.2",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7658,11 +7517,11 @@
         "ssri": "^8.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "3.1.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7670,11 +7529,11 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "2.0.4",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7683,20 +7542,23 @@
         "npm-registry-fetch": "^11.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "1.2.1",
+      "version": "2.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^2.0.7",
-        "@npmcli/run-script": "^1.8.4",
+        "@npmcli/run-script": "^2.0.0",
         "json-parse-even-better-errors": "^2.3.1",
         "semver": "^7.3.5",
         "stringify-package": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
@@ -7738,27 +7600,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/mime-db": {
-      "version": "1.49.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.32",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.49.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/npm/node_modules/minimatch": {
       "version": "3.0.4",
       "dev": true,
@@ -7772,7 +7613,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.5",
+      "version": "3.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7919,20 +7760,20 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "7.1.2",
+      "version": "8.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
-        "graceful-fs": "^4.2.3",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
         "nopt": "^5.0.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.88.2",
+        "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
-        "semver": "^7.3.2",
-        "tar": "^6.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
         "which": "^2.0.2"
       },
       "bin": {
@@ -7940,66 +7781,6 @@
       },
       "engines": {
         "node": ">= 10.12.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-      "version": "2.7.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
-      "version": "4.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/npm/node_modules/nopt": {
@@ -8086,13 +7867,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "2.2.2",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.6",
-        "ignore-walk": "^3.0.3",
+        "ignore-walk": "^4.0.1",
         "npm-bundled": "^1.1.1",
         "npm-normalize-package-bin": "^1.0.1"
       },
@@ -8151,46 +7932,18 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "5.0.1",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
         "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
+        "gauge": "^4.0.0",
         "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/object-assign": {
@@ -8236,7 +7989,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.5",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8244,7 +7997,7 @@
         "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
-        "@npmcli/run-script": "^1.8.2",
+        "@npmcli/run-script": "^2.0.0",
         "cacache": "^15.0.5",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.1.0",
@@ -8252,7 +8005,7 @@
         "minipass": "^3.1.3",
         "mkdirp": "^1.0.3",
         "npm-package-arg": "^8.0.1",
-        "npm-packlist": "^2.1.4",
+        "npm-packlist": "^3.0.0",
         "npm-pick-manifest": "^6.0.0",
         "npm-registry-fetch": "^11.0.0",
         "promise-retry": "^2.0.1",
@@ -8265,18 +8018,21 @@
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "1.1.1",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^2.3.0",
-        "just-diff": "^3.0.1",
-        "just-diff-apply": "^3.0.0"
+        "json-parse-even-better-errors": "^2.3.1",
+        "just-diff": "^5.0.1",
+        "just-diff-apply": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/path-is-absolute": {
@@ -8287,12 +8043,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/npm/node_modules/performance-now": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "1.0.0",
@@ -8346,36 +8096,12 @@
         "read": "1"
       }
     },
-    "node_modules/npm/node_modules/psl": {
-      "version": "1.8.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/punycode": {
-      "version": "2.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
-    "node_modules/npm/node_modules/qs": {
-      "version": "6.5.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/npm/node_modules/read": {
@@ -8450,64 +8176,6 @@
         "once": "^1.3.0"
       }
     },
-    "node_modules/npm/node_modules/request": {
-      "version": "2.88.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/form-data": {
-      "version": "2.3.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/npm/node_modules/request/node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -8556,7 +8224,8 @@
       "version": "2.1.2",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.3.5",
@@ -8580,7 +8249,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "3.0.3",
+      "version": "3.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -8654,31 +8323,6 @@
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/npm/node_modules/sshpk": {
-      "version": "1.16.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "8.0.1",
@@ -8800,24 +8444,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "Unlicense"
-    },
     "node_modules/npm/node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -8845,29 +8471,11 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "node_modules/npm/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/uuid": {
-      "version": "3.4.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -8886,20 +8494,6 @@
       "license": "ISC",
       "dependencies": {
         "builtins": "^1.0.3"
-      }
-    },
-    "node_modules/npm/node_modules/verror": {
-      "version": "1.10.0",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
@@ -10396,15 +9990,15 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/semantic-release": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.1.tgz",
-      "integrity": "sha512-xTdKCaEnCzHr+Fqyhg/5I8P9pvY9z7WHa8TFCYIwcdPbuzAtQShOTzw3VNPsqBT+Yq1kFyBQFBKBYkGOlqWmfA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
         "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
@@ -10418,8 +10012,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -10434,7 +10028,7 @@
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16 || ^14.17"
       }
     },
     "node_modules/semver": {
@@ -12866,9 +12460,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-8.0.3.tgz",
-      "integrity": "sha512-Qbg7x/O1t3sJqsv2+U0AL4Utgi/ymlCiUdt67Ftz9HL9N8aDML4t2tE0T9MBaYdqwD976hz57DqHHXKVppUBoA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.0.tgz",
+      "integrity": "sha512-hj2jqayS2SPUmFtCMCOQMX975uMDfRoymj1HvMSwYdaoI6hVZvhrTFPBgJeM85O0C+G3IFviAUar5gel/1VGDQ==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
@@ -12878,7 +12472,7 @@
         "lodash": "^4.17.15",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^6.0.0",
-        "npm": "^7.0.0",
+        "npm": "^8.3.0",
         "rc": "^1.2.8",
         "read-pkg": "^5.0.0",
         "registry-auth-token": "^4.0.0",
@@ -13057,18 +12651,18 @@
       }
     },
     "ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.21.3"
+        "type-fest": "^1.0.2"
       },
       "dependencies": {
         "type-fest": {
-          "version": "0.21.3",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
           "dev": true
         }
       }
@@ -13709,13 +13303,14 @@
       "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
       "dev": true
     },
-    "cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+    "cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "1.4.0",
+        "string-width": "^4.2.0"
       }
     },
     "cli-truncate": {
@@ -13807,10 +13402,11 @@
       "dev": true
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "optional": true
     },
     "commander": {
       "version": "6.2.1",
@@ -16139,12 +15735,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -16217,23 +15807,31 @@
       }
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
-      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.0.0.tgz",
+      "integrity": "sha512-26604GmGmW63ElxcXpE2xfMdbtgD/qiwIqOh/+5+uPe6NVU4bU433+wvPTfq6NZcGr16KWqwu/dzsKxg3IL2Xw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.3.1",
+        "ansi-escapes": "^5.0.0",
         "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table": "^0.3.1",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
+        "chalk": "^5.0.0",
+        "cli-table3": "^0.6.0",
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.2.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+          "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+          "dev": true
+        }
       }
     },
     "matcher": {
@@ -16471,12 +16069,12 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node-fetch": {
@@ -16534,9 +16132,9 @@
       "dev": true
     },
     "npm": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
-      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.3.1.tgz",
+      "integrity": "sha512-f552vKhT3r+PpCRnH7UferrrbcnvcFnGusN2T1mQqq/0UQd3pF1+ok4n0WahT0ZKxj10YU3b2VdhGrf39djHAA==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "*",
@@ -16594,6 +16192,7 @@
         "opener": "*",
         "pacote": "*",
         "parse-conflict-json": "*",
+        "proc-log": "*",
         "qrcode-terminal": "*",
         "read": "*",
         "read-package-json": "*",
@@ -16622,20 +16221,20 @@
           "dev": true
         },
         "@npmcli/arborist": {
-          "version": "2.9.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@isaacs/string-locale-compare": "^1.0.1",
+            "@isaacs/string-locale-compare": "^1.1.0",
             "@npmcli/installed-package-contents": "^1.0.7",
-            "@npmcli/map-workspaces": "^1.0.2",
-            "@npmcli/metavuln-calculator": "^1.1.0",
+            "@npmcli/map-workspaces": "^2.0.0",
+            "@npmcli/metavuln-calculator": "^2.0.0",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
-            "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/node-gyp": "^1.0.3",
             "@npmcli/package-json": "^1.0.1",
-            "@npmcli/run-script": "^1.8.2",
-            "bin-links": "^2.2.1",
+            "@npmcli/run-script": "^2.0.0",
+            "bin-links": "^2.3.0",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
@@ -16646,8 +16245,8 @@
             "npm-package-arg": "^8.1.5",
             "npm-pick-manifest": "^6.1.0",
             "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.3.5",
-            "parse-conflict-json": "^1.1.1",
+            "pacote": "^12.0.2",
+            "parse-conflict-json": "^2.0.1",
             "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
@@ -16661,12 +16260,12 @@
           }
         },
         "@npmcli/ci-detect": {
-          "version": "1.3.0",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.3.0",
+          "version": "2.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -16719,7 +16318,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.4",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -16730,12 +16329,13 @@
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "1.1.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "cacache": "^15.0.5",
-            "pacote": "^11.1.11",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^12.0.0",
             "semver": "^7.3.2"
           }
         },
@@ -16754,7 +16354,7 @@
           "dev": true
         },
         "@npmcli/node-gyp": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
@@ -16775,13 +16375,13 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.6",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "node-gyp": "^7.1.0",
+            "node-gyp": "^8.2.0",
             "read-package-json-fast": "^2.0.1"
           }
         },
@@ -16804,7 +16404,7 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.1.4",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -16820,17 +16420,6 @@
           "requires": {
             "clean-stack": "^2.0.0",
             "indent-string": "^4.0.0"
-          }
-        },
-        "ajv": {
-          "version": "6.12.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
           }
         },
         "ansi-regex": {
@@ -16867,7 +16456,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.6",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -16880,54 +16469,18 @@
           "bundled": true,
           "dev": true
         },
-        "asn1": {
-          "version": "0.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safer-buffer": "~2.1.0"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.11.0",
-          "bundled": true,
-          "dev": true
-        },
         "balanced-match": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "tweetnacl": "^0.14.3"
-          }
-        },
         "bin-links": {
-          "version": "2.2.1",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "cmd-shim": "^4.0.1",
-            "mkdirp": "^1.0.3",
+            "mkdirp-infer-owner": "^2.0.0",
             "npm-normalize-package-bin": "^1.0.0",
             "read-cmd-shim": "^2.0.0",
             "rimraf": "^3.0.0",
@@ -16978,11 +16531,6 @@
             "unique-filename": "^1.1.1"
           }
         },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.2",
           "bundled": true,
@@ -17011,12 +16559,42 @@
           "dev": true
         },
         "cli-columns": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.1"
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         },
         "cli-table3": {
@@ -17072,11 +16650,6 @@
             "mkdirp-infer-owner": "^2.0.0"
           }
         },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "color-convert": {
           "version": "2.0.1",
           "bundled": true,
@@ -17110,14 +16683,6 @@
             "wcwidth": "^1.0.0"
           }
         },
-        "combined-stream": {
-          "version": "1.0.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
         "common-ancestor-path": {
           "version": "1.0.1",
           "bundled": true,
@@ -17132,19 +16697,6 @@
           "version": "1.1.0",
           "bundled": true,
           "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
-          }
         },
         "debug": {
           "version": "4.3.2",
@@ -17174,11 +16726,6 @@
             "clone": "^1.0.2"
           }
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
@@ -17202,15 +16749,6 @@
           "version": "5.0.0",
           "bundled": true,
           "dev": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
-          }
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -17236,33 +16774,8 @@
           "bundled": true,
           "dev": true
         },
-        "extend": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "fastest-levenshtein": {
           "version": "1.0.12",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
           "bundled": true,
           "dev": true
         },
@@ -17285,27 +16798,49 @@
           "dev": true
         },
         "gauge": {
-          "version": "3.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "ansi-regex": "^5.0.1",
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
             "has-unicode": "^2.0.1",
-            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1 || ^2.0.0",
-            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
             "wide-align": "^1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "string-width": {
+              "version": "4.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+              }
+            },
+            "strip-ansi": {
+              "version": "6.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.1"
+              }
+            }
           }
         },
         "glob": {
@@ -17326,20 +16861,6 @@
           "bundled": true,
           "dev": true
         },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "har-validator": {
-          "version": "5.1.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
-          }
-        },
         "has": {
           "version": "1.0.3",
           "bundled": true,
@@ -17359,7 +16880,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17379,16 +16900,6 @@
             "@tootallnate/once": "1",
             "agent-base": "6",
             "debug": "4"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
           }
         },
         "https-proxy-agent": {
@@ -17418,7 +16929,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.4",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17492,7 +17003,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.7.0",
+          "version": "2.8.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17519,28 +17030,8 @@
           "bundled": true,
           "dev": true
         },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "json-parse-even-better-errors": {
           "version": "2.3.1",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
           "bundled": true,
           "dev": true
         },
@@ -17549,39 +17040,23 @@
           "bundled": true,
           "dev": true
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "jsonparse": {
           "version": "1.3.1",
           "bundled": true,
           "dev": true
         },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
         "just-diff": {
-          "version": "3.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
         "just-diff-apply": {
-          "version": "3.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true
         },
         "libnpmaccess": {
-          "version": "4.0.3",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17592,7 +17067,7 @@
           }
         },
         "libnpmdiff": {
-          "version": "2.0.4",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17602,22 +17077,22 @@
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
             "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "pacote": "^12.0.0",
             "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "2.0.1",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.3.0",
+            "@npmcli/arborist": "^4.0.0",
             "@npmcli/ci-detect": "^1.3.0",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/run-script": "^2.0.0",
             "chalk": "^4.1.0",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-package-arg": "^8.1.2",
-            "pacote": "^11.3.1",
+            "pacote": "^12.0.0",
             "proc-log": "^1.0.0",
             "read": "^1.0.7",
             "read-package-json-fast": "^2.0.2",
@@ -17625,15 +17100,15 @@
           }
         },
         "libnpmfund": {
-          "version": "1.1.0",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^2.5.0"
+            "@npmcli/arborist": "^4.0.0"
           }
         },
         "libnpmhook": {
-          "version": "6.0.3",
+          "version": "7.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17642,7 +17117,7 @@
           }
         },
         "libnpmorg": {
-          "version": "2.0.3",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17651,17 +17126,17 @@
           }
         },
         "libnpmpack": {
-          "version": "2.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/run-script": "^1.8.3",
+            "@npmcli/run-script": "^2.0.0",
             "npm-package-arg": "^8.1.0",
-            "pacote": "^11.2.6"
+            "pacote": "^12.0.0"
           }
         },
         "libnpmpublish": {
-          "version": "4.0.2",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17673,7 +17148,7 @@
           }
         },
         "libnpmsearch": {
-          "version": "3.1.2",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17681,7 +17156,7 @@
           }
         },
         "libnpmteam": {
-          "version": "2.0.4",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17690,12 +17165,12 @@
           }
         },
         "libnpmversion": {
-          "version": "1.2.1",
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.0.7",
-            "@npmcli/run-script": "^1.8.4",
+            "@npmcli/run-script": "^2.0.0",
             "json-parse-even-better-errors": "^2.3.1",
             "semver": "^7.3.5",
             "stringify-package": "^1.0.1"
@@ -17732,19 +17207,6 @@
             "ssri": "^8.0.0"
           }
         },
-        "mime-db": {
-          "version": "1.49.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.32",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.49.0"
-          }
-        },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
@@ -17754,7 +17216,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.5",
+          "version": "3.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -17853,71 +17315,20 @@
           "dev": true
         },
         "node-gyp": {
-          "version": "7.1.2",
+          "version": "8.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
-            "graceful-fs": "^4.2.3",
+            "graceful-fs": "^4.2.6",
+            "make-fetch-happen": "^9.1.0",
             "nopt": "^5.0.0",
-            "npmlog": "^4.1.2",
-            "request": "^2.88.2",
+            "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
-            "semver": "^7.3.2",
-            "tar": "^6.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.2",
             "which": "^2.0.2"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "4.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
           }
         },
         "nopt": {
@@ -17979,12 +17390,12 @@
           }
         },
         "npm-packlist": {
-          "version": "2.2.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^7.1.6",
-            "ignore-walk": "^3.0.3",
+            "ignore-walk": "^4.0.1",
             "npm-bundled": "^1.1.1",
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -18027,36 +17438,15 @@
           "dev": true
         },
         "npmlog": {
-          "version": "5.0.1",
+          "version": "6.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "are-we-there-yet": "^2.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^3.0.0",
+            "gauge": "^4.0.0",
             "set-blocking": "^2.0.0"
-          },
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "2.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            }
           }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "bundled": true,
-          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -18085,14 +17475,14 @@
           }
         },
         "pacote": {
-          "version": "11.3.5",
+          "version": "12.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
-            "@npmcli/run-script": "^1.8.2",
+            "@npmcli/run-script": "^2.0.0",
             "cacache": "^15.0.5",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.1.0",
@@ -18100,7 +17490,7 @@
             "minipass": "^3.1.3",
             "mkdirp": "^1.0.3",
             "npm-package-arg": "^8.0.1",
-            "npm-packlist": "^2.1.4",
+            "npm-packlist": "^3.0.0",
             "npm-pick-manifest": "^6.0.0",
             "npm-registry-fetch": "^11.0.0",
             "promise-retry": "^2.0.1",
@@ -18111,22 +17501,17 @@
           }
         },
         "parse-conflict-json": {
-          "version": "1.1.1",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "json-parse-even-better-errors": "^2.3.0",
-            "just-diff": "^3.0.1",
-            "just-diff-apply": "^3.0.0"
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
+            "just-diff-apply": "^4.0.1"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
           "bundled": true,
           "dev": true
         },
@@ -18167,23 +17552,8 @@
             "read": "1"
           }
         },
-        "psl": {
-          "version": "1.8.0",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
-          "dev": true
-        },
-        "qs": {
-          "version": "6.5.2",
           "bundled": true,
           "dev": true
         },
@@ -18241,54 +17611,6 @@
             "once": "^1.3.0"
           }
         },
-        "request": {
-          "version": "2.88.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
-          },
-          "dependencies": {
-            "form-data": {
-              "version": "2.3.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
-              }
-            },
-            "tough-cookie": {
-              "version": "2.5.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
-              }
-            }
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -18310,7 +17632,8 @@
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "7.3.5",
@@ -18326,7 +17649,7 @@
           "dev": true
         },
         "signal-exit": {
-          "version": "3.0.3",
+          "version": "3.0.6",
           "bundled": true,
           "dev": true
         },
@@ -18381,22 +17704,6 @@
           "version": "3.0.10",
           "bundled": true,
           "dev": true
-        },
-        "sshpk": {
-          "version": "1.16.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
-          }
         },
         "ssri": {
           "version": "8.0.1",
@@ -18487,19 +17794,6 @@
           "bundled": true,
           "dev": true
         },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true
-        },
         "typedarray-to-buffer": {
           "version": "3.1.5",
           "bundled": true,
@@ -18524,21 +17818,8 @@
             "imurmurhash": "^0.1.4"
           }
         },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
           "bundled": true,
           "dev": true
         },
@@ -18557,16 +17838,6 @@
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
-          }
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
           }
         },
         "walk-up-path": {
@@ -19664,15 +18935,15 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semantic-release": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-18.0.1.tgz",
-      "integrity": "sha512-xTdKCaEnCzHr+Fqyhg/5I8P9pvY9z7WHa8TFCYIwcdPbuzAtQShOTzw3VNPsqBT+Yq1kFyBQFBKBYkGOlqWmfA==",
+      "version": "19.0.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
+      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/error": "^3.0.0",
         "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^8.0.0",
+        "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
@@ -19686,8 +18957,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^2.0.0",
-        "marked-terminal": "^4.1.1",
+        "marked": "^4.0.10",
+        "marked-terminal": "^5.0.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "husky": "^7.0.4",
     "nyc": "^15.1.0",
     "proxyquire": "^2.1.3",
-    "semantic-release": "^18.0.1",
+    "semantic-release": "^19.0.2",
     "sinon": "^12.0.1"
   }
 }


### PR DESCRIPTION
But the peer dependency still supports v18 and higher.
