### PR TITLE
refactor!: drop `yarn` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Use `semantic-release-vsce` as part of `verifyConditions` and `publish`.
 If `packageVsix` is set, will also generate a .vsix file at the set file path after publishing. If is a string, it will be used as value for `--out` of `vsce package`.
 It is recommended to upload this to your GitHub release page so your users can easily rollback to an earlier version if a version ever introduces a bad bug. 
 
-If `yarn` is set to `true`, will use `--yarn`option for `vsce package` and `vsce publish`.
-
 #### Publishing to OpenVSX
 
 Publishing extensions to OpenVSX using this plugin is easy:

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ async function prepare (pluginConfig, { nextRelease: { version }, logger }) {
     await verifyVsce(logger);
     verified = true;
   }
-  packagePath = await vscePrepare(version, pluginConfig.packageVsix, pluginConfig.yarn, logger);
+  packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger);
   prepared = true;
 }
 
@@ -28,9 +28,9 @@ async function publish (pluginConfig, { nextRelease: { version }, logger }) {
 
   if (!prepared) {
     // BC: prior to semantic-release v15 prepare was part of publish
-    packagePath = await vscePrepare(version, pluginConfig.packageVsix, pluginConfig.yarn, logger);
+    packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger);
   }
-  return vscePublish(version, packagePath, pluginConfig.yarn, logger);
+  return vscePublish(version, packagePath, logger);
 }
 
 module.exports = {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 const { isOvsxEnabled } = require('./verify-ovsx-auth');
 
-module.exports = async (version, packageVsix, yarn, logger) => {
+module.exports = async (version, packageVsix, logger) => {
   const ovsxEnabled = isOvsxEnabled();
   if (packageVsix || ovsxEnabled) {
     if (!packageVsix && ovsxEnabled) {
@@ -21,10 +21,6 @@ module.exports = async (version, packageVsix, yarn, logger) => {
     logger.log(`Packaging version ${version} to ${packagePath}`);
 
     const options = ['package', version, '--no-git-tag-version', '--out', packagePath];
-
-    if (yarn) {
-      options.push('--yarn');
-    }
 
     await execa('vsce', options, { stdio: 'inherit' });
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 const { isOvsxEnabled } = require('./verify-ovsx-auth');
 
-module.exports = async (version, packagePath, yarn, logger) => {
+module.exports = async (version, packagePath, logger) => {
   const { publisher, name } = await readJson('./package.json');
 
   const options = ['publish'];
@@ -13,10 +13,6 @@ module.exports = async (version, packagePath, yarn, logger) => {
   } else {
     logger.log(`Publishing version ${version} to Visual Studio Marketplace`);
     options.push(...[version, '--no-git-tag-version']);
-  }
-
-  if (yarn) {
-    options.push('--yarn');
   }
 
   await execa('vsce', options, { stdio: 'inherit' });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,8 +12,7 @@ const semanticReleasePayload = {
 };
 
 const pluginConfig = {
-  packageVsix: 'test.vsix',
-  yarn: undefined
+  packageVsix: 'test.vsix'
 };
 
 test.beforeEach(t => {
@@ -58,7 +57,6 @@ test('prepare and unverified', async t => {
   t.deepEqual(vscePrepareStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     pluginConfig.packageVsix,
-    pluginConfig.yarn,
     semanticReleasePayload.logger
   ]);
 });
@@ -78,7 +76,6 @@ test('prepare and verified', async t => {
   t.deepEqual(vscePrepareStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     pluginConfig.packageVsix,
-    pluginConfig.yarn,
     semanticReleasePayload.logger
   ]);
 });
@@ -98,7 +95,6 @@ test('publish that is unverified and unprepared', async t => {
   t.deepEqual(vscePublishStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     undefined,
-    pluginConfig.yarn,
     semanticReleasePayload.logger
   ]);
 });
@@ -119,7 +115,6 @@ test('publish that is verified but unprepared', async t => {
   t.deepEqual(vscePublishStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     undefined,
-    pluginConfig.yarn,
     semanticReleasePayload.logger
   ]);
 });
@@ -141,7 +136,6 @@ test('publish that is already verified & prepared', async t => {
   t.deepEqual(vscePublishStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     packagePath,
-    pluginConfig.yarn,
     semanticReleasePayload.logger
   ]);
 });

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -23,20 +23,7 @@ test('packageVsix is not specified', async t => {
   });
 
   const version = '1.0.0';
-  await prepare(version, undefined, undefined, logger);
-
-  t.true(execaStub.notCalled);
-});
-
-test('packageVsix is not specified but yarn is true', async t => {
-  const { execaStub } = t.context.stubs;
-  const prepare = proxyquire('../lib/prepare', {
-    execa: execaStub
-  });
-
-  const version = '1.0.0';
-  const yarn = true;
-  await prepare(version, undefined, yarn, logger);
+  await prepare(version, undefined, logger);
 
   t.true(execaStub.notCalled);
 });
@@ -50,7 +37,7 @@ test('packageVsix is a string', async t => {
   const version = '1.0.0';
   const packageVsix = 'test.vsix';
   const packagePath = packageVsix;
-  const result = await prepare(version, packageVsix, undefined, logger);
+  const result = await prepare(version, packageVsix, logger);
 
   t.deepEqual(result, packagePath);
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit' }]);
@@ -73,34 +60,10 @@ test('packageVsix is true', async t => {
   const packageVsix = true;
   const packagePath = `${name}-${version}.vsix`;
 
-  const result = await prepare(version, packageVsix, undefined, logger);
+  const result = await prepare(version, packageVsix, logger);
 
   t.deepEqual(result, packagePath);
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit' }]);
-});
-
-test('packageVsix is true and yarn is true', async t => {
-  const { execaStub } = t.context.stubs;
-  const name = 'test';
-
-  const prepare = proxyquire('../lib/prepare', {
-    execa: execaStub,
-    'fs-extra': {
-      readJson: sinon.stub().returns({
-        name
-      })
-    }
-  });
-
-  const version = '1.0.0';
-  const packageVsix = true;
-  const yarn = true;
-  const packagePath = `${name}-${version}.vsix`;
-
-  const result = await prepare(version, packageVsix, yarn, logger);
-
-  t.deepEqual(result, packagePath);
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath, '--yarn'], { stdio: 'inherit' }]);
 });
 
 test('packageVsix is not set but OVSX_PAT is', async t => {
@@ -124,7 +87,7 @@ test('packageVsix is not set but OVSX_PAT is', async t => {
   const packageVsix = undefined;
   const packagePath = `${name}-${version}.vsix`;
 
-  const result = await prepare(version, packageVsix, undefined, logger);
+  const result = await prepare(version, packageVsix, logger);
 
   t.deepEqual(result, packagePath);
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit' }]);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -35,7 +35,7 @@ test('publish', async t => {
   sinon.stub(process, 'env').value({
     VSCE_PAT: token
   });
-  const result = await publish(version, undefined, undefined, logger);
+  const result = await publish(version, undefined, logger);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
@@ -64,42 +64,13 @@ test('publish with packagePath', async t => {
   sinon.stub(process, 'env').value({
     VSCE_PAT: token
   });
-  const result = await publish(version, packagePath, undefined, logger);
+  const result = await publish(version, packagePath, logger);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
   });
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--packagePath', packagePath], { stdio: 'inherit' }]);
-});
-
-test('publish when yarn is true', async t => {
-  const { execaStub } = t.context.stubs;
-  const publisher = 'semantic-release-vsce';
-  const name = 'Semantice Release VSCE';
-  const publish = proxyquire('../lib/publish', {
-    execa: execaStub,
-    'fs-extra': {
-      readJson: sinon.stub().returns({
-        publisher,
-        name
-      })
-    }
-  });
-
-  const version = '1.0.0';
-  const token = 'abc123';
-  sinon.stub(process, 'env').value({
-    VSCE_PAT: token
-  });
-  const yarn = true;
-  const result = await publish(version, undefined, yarn, logger);
-
-  t.deepEqual(result, {
-    name: 'Visual Studio Marketplace',
-    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
-  });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', version, '--no-git-tag-version', '--yarn'], { stdio: 'inherit' }]);
 });
 
 test('publish with VSCE_PAT and VSCE_TOKEN should prefer VSCE_PAT', async t => {
@@ -122,7 +93,7 @@ test('publish with VSCE_PAT and VSCE_TOKEN should prefer VSCE_PAT', async t => {
     VSCE_PAT: token,
     VSCE_TOKEN: token
   });
-  const result = await publish(version, undefined, undefined, logger);
+  const result = await publish(version, undefined, logger);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
@@ -152,7 +123,7 @@ test('publish to OpenVSX', async t => {
     OVSX_PAT: token,
     VSCE_TOKEN: token
   });
-  const result = await publish(version, packagePath, undefined, logger);
+  const result = await publish(version, packagePath, logger);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',


### PR DESCRIPTION
As `vsce` now supports configuration through the `package.json` file
(see https://github.com/microsoft/vscode-vsce/issues/548), this option
was dropped to simplify the codebase. One should either rely on the
`vsce` automatically detecting when to use `yarn` (see
https://github.com/microsoft/vscode-vsce/issues/480), or add the
following to `package.json`:

```json
{
    "vsce": {
        "yarn": true
    }
}
```
