### PR TITLE
refactor!: drop support for `VSCE_TOKEN`

### DIFF
--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -4,11 +4,6 @@ const SemanticReleaseError = require('@semantic-release/error');
 module.exports = async (logger) => {
   logger.log('Verifying authentication for vsce');
 
-  if (!('VSCE_PAT' in process.env) && ('VSCE_TOKEN' in process.env)) {
-    logger.log('VSCE_TOKEN is deprecated and may be removed in the next major release, please use VSCE_PAT instead.');
-    process.env.VSCE_PAT = process.env.VSCE_TOKEN;
-  }
-
   if (!process.env.VSCE_PAT) {
     throw new SemanticReleaseError('No vsce personal access token specified (set the `VSCE_PAT` environment variable).', 'ENOVSCEPAT');
   }

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -73,35 +73,6 @@ test('publish with packagePath', async t => {
   t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--packagePath', packagePath], { stdio: 'inherit' }]);
 });
 
-test('publish with VSCE_PAT and VSCE_TOKEN should prefer VSCE_PAT', async t => {
-  const { execaStub } = t.context.stubs;
-  const publisher = 'semantic-release-vsce';
-  const name = 'Semantice Release VSCE';
-  const publish = proxyquire('../lib/publish', {
-    execa: execaStub,
-    'fs-extra': {
-      readJson: sinon.stub().returns({
-        publisher,
-        name
-      })
-    }
-  });
-
-  const version = '1.0.0';
-  const token = 'abc123';
-  sinon.stub(process, 'env').value({
-    VSCE_PAT: token,
-    VSCE_TOKEN: token
-  });
-  const result = await publish(version, undefined, logger);
-
-  t.deepEqual(result, {
-    name: 'Visual Studio Marketplace',
-    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
-  });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', version, '--no-git-tag-version'], { stdio: 'inherit' }]);
-});
-
 test('publish to OpenVSX', async t => {
   const { execaStub } = t.context.stubs;
   const publisher = 'semantic-release-vsce';
@@ -121,7 +92,7 @@ test('publish to OpenVSX', async t => {
   const token = 'abc123';
   sinon.stub(process, 'env').value({
     OVSX_PAT: token,
-    VSCE_TOKEN: token
+    VSCE_PAT: token
   });
   const result = await publish(version, packagePath, logger);
 

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -7,28 +7,6 @@ const logger = {
   log: sinon.fake()
 };
 
-test('VSCE_TOKEN is set', async t => {
-  sinon.stub(process, 'env').value({
-    VSCE_TOKEN: 'abc123'
-  });
-
-  const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat']).resolves()
-  });
-
-  await t.notThrowsAsync(() => verifyAuth(logger));
-});
-
-test('VSCE_TOKEN is not set', async t => {
-  sinon.stub(process, 'env').value({});
-
-  const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat']).resolves()
-  });
-
-  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
-});
-
 test('VSCE_PAT is set', async t => {
   sinon.stub(process, 'env').value({
     VSCE_PAT: 'abc123'
@@ -49,30 +27,6 @@ test('VSCE_PAT is not set', async t => {
   });
 
   await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
-});
-
-test('VSCE_TOKEN is valid', async t => {
-  sinon.stub(process, 'env').value({
-    VSCE_TOKEN: 'abc123'
-  });
-
-  const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat']).resolves()
-  });
-
-  await t.notThrowsAsync(() => verifyAuth(logger));
-});
-
-test('VSCE_TOKEN is invalid', async t => {
-  sinon.stub(process, 'env').value({
-    VSCE_TOKEN: 'abc123'
-  });
-
-  const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat']).rejects()
-  });
-
-  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'EINVALIDVSCETOKEN' });
 });
 
 test('VSCE_PAT is valid', async t => {


### PR DESCRIPTION
As this was already deprecated, the `VSCE_TOKEN` is not supported
anymore in favor of `VSCE_PAT` which is already supported by `vsce`
itself. If you have a `VSCE_TOKEN` set, please unset it and set
`VSCE_PAT` instead.
