### PR TITLE
feat: add support for publishing platform-specific `.vsix`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,26 +1,14 @@
 {
-    "env": {
-        "es6": true,
-        "node": true
-    },
-    "extends": "standard",
-    "rules": {
-        "no-console": "off",
-        "indent": [
-            "error",
-            2
-        ],
-        "linebreak-style": [
-            "error",
-            "unix"
-        ],
-        "quotes": [
-            "error",
-            "single"
-        ],
-        "semi": [
-            "error",
-            "always"
-        ]
-    }
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": ["standard", "prettier"],
+  "rules": {
+    "no-console": "off",
+    "indent": ["error", 2],
+    "linebreak-style": ["error", "unix"],
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"]
+  }
 }

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,0 +1,16 @@
+name: validate-pr-title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+npx lint-staged
 npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.nyc_output

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ Which `.vsix` file (or files) to publish. This controls what value will be used 
 
 ### Environment variables
 
-| Variable   | Description                                                                                                                        |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `VSCE_PAT` | **Required** (unless `publish` is set to `false`). The personal access token to publish the extension to Visual Studio Marketplace |
-| `OVSX_PAT` | _Optional_. The personal access token to push to OpenVSX                                                                           |
+| Variable      | Description                                                                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `VSCE_PAT`    | **Required** (unless `publish` is set to `false`). The personal access token to publish the extension to Visual Studio Marketplace                                                                     |
+| `VSCE_TARGET` | _Optional_. The target to use when packaging or publishing the extension (used as `vsce package --target ${VSCE_TARGET}`). See [the platform-specific example](#platform-specific-on-github-actions) ) |
+| `OVSX_PAT`    | _Optional_. The personal access token to push to OpenVSX                                                                                                                                               |
 
 ### Publishing to OpenVSX
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 [![peerDependencies](https://david-dm.org/felipecrs/semantic-release-vsce/peer-status.svg)](https://david-dm.org/felipecrs/semantic-release-vsce?type=peer)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-| Step      | Description                                                                                                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `verify`  | Verify the presence and the validity of the authentication (set via [environment variables](#environment-variables)) and the `package.json`                                                 |
-| `prepare` | Generate the `.vsix` file using vsce, this can be be controlled by providing `packageVsix` in config. <br/> _Note: If the `OVSX_PAT` environment variable is set, this step will still run_ |
-| `publish` | Publish the extension                                                                                                                                                                       |
+| Step      | Description                                                                                                                                                                                                          |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `verify`  | Verify the presence and the validity of the authentication (set via [environment variables](#environment-variables)) and the `package.json`                                                                          |
+| `prepare` | Generate the `.vsix` file using vsce, this can be be controlled by providing `packageVsix` in config. <br/> _Note: If the `OVSX_PAT` environment variable is set, this step will run even if not explicitly enabled_ |
+| `publish` | Publish the extension                                                                                                                                                                                                |
 
 ## Install
 
@@ -47,8 +47,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
       {
         "assets": [
           {
-            "path": "*.vsix",
-            "label": "Extension File"
+            "path": "*.vsix"
           }
         ]
       }
@@ -59,17 +58,42 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 
 ## Configuration
 
-| Option        | Type                  | Description                                                                                                                        |
-| ------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `packageVsix` | `boolean` or `string` | If set to `true`, the plugin will generate a `.vsix` file. If is a string, it will be used as value for `--out` of `vsce package`. |
-| `publish`     | `boolean`             | The plugin will publish the package unless this option is set to `false`, in which case it will only package the extension `vsix`.        |
+### `packageVsix`
 
-### Environment Variables
+Whether to package or not the extension `.vsix`, or where to place it. This controls if `vsce package` gets called or not, and what value will be used for `vsce package --out`.
 
-| Variable   | Description                                                                                                                  |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `VSCE_PAT` | _**Required**_ unless `publish` is set to `false`. The personal access token to publish the extension of VS Code Marketplace |
-| `OVSX_PAT` | _Optional_. The personal access token to push to OpenVSX                                                                     |
+| Value              | Description                                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `"auto"` (default) | behave as `true` in case [`publish`](#publish) is disabled or the `OVSX_PAT` environment variable is present |
+| `true`             | package the extension `.vsix`, and place it at the current working directory                                 |
+| `false`            | disables packaging the extension `.vsix` entirely                                                            |
+| a `string`         | package the extension `.vsix` and place it at the specified path                                             |
+
+### `publish`
+
+Whether to publish or not the extension to Visual Studio Marketplace. This controls if `vsce publish` gets called or not.
+
+| Value            | Description                                                    |
+| ---------------- | -------------------------------------------------------------- |
+| `true` (default) | publishes the extension to Visual Studio Marketplace           |
+| `false`          | disables publishing the extension to Visual Studio Marketplace |
+
+### `publishPackagePath`
+
+Which `.vsix` file (or files) to publish. This controls what value will be used for `vsce publish --packagePath`.
+
+| Value              | Description                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `"auto"` (default) | uses the `.vsix` packaged during the `prepare` step (if packaged)                                                 |
+| `false`            | do not use a `.vsix` file to publish, which causes `vsce` to package the extension as part of the publish process |
+| a `string`         | publish the specified `.vsix` file(s). This can be a glob pattern, or a comma-separated list of files             |
+
+### Environment variables
+
+| Variable   | Description                                                                                                                        |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `VSCE_PAT` | **Required** (unless `publish` is set to `false`). The personal access token to publish the extension to Visual Studio Marketplace |
+| `OVSX_PAT` | _Optional_. The personal access token to push to OpenVSX                                                                           |
 
 ### Publishing to OpenVSX
 
@@ -79,9 +103,11 @@ Publishing extensions to OpenVSX using this plugin is easy:
 
 2. Configure the `OVSX_PAT` environment variable in your CI with the token that you created.
 
-3. The plugin will automatically detect the environment variable and it will publish to OpenVSX, no additional configuration is needed. Enjoy!
+3. Enjoy! The plugin will automatically detect the environment variable and it will publish to OpenVSX, no additional configuration is needed.
 
-### Github Actions Example
+## Examples
+
+### Github Actions
 
 ```yaml
 name: release
@@ -98,11 +124,145 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Install Node Dependencies
-        run: npm ci
-      - name: Release
-        run: npx semantic-release
+      - run: npm ci
+      - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          # In case you want to publish to OpenVSX
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+```
+
+### Platform-specific on GitHub Actions
+
+```console
+npm install --save-dev semantic-release-export-data
+```
+
+```json
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "semantic-release-export-data",
+    [
+      "semantic-release-vsce",
+      {
+        "packageVsix": false,
+        "publishPackagePath": "*.vsix"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "assets": "*.vsix"
+      }
+    ]
+  ]
+}
+```
+
+```yaml
+# .github/workflows/ci.yaml
+name: ci
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  get-next-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npx semantic-release --dry-run
+        id: get-next-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          # In case you want to publish to OpenVSX
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+    outputs:
+      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+      new-release-version: ${{ steps.get-next-version.outputs.new-release-version }}
+
+  build:
+    needs: get-next-version
+    if: needs.get-next-version.outputs.new-release-published == 'true'
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win32
+            arch: x64
+            npm_config_arch: x64
+          - os: windows-latest
+            platform: win32
+            arch: ia32
+            npm_config_arch: ia32
+          - os: windows-latest
+            platform: win32
+            arch: arm64
+            npm_config_arch: arm
+          - os: ubuntu-latest
+            platform: linux
+            arch: x64
+            npm_config_arch: x64
+          - os: ubuntu-latest
+            platform: linux
+            arch: arm64
+            npm_config_arch: arm64
+          - os: ubuntu-latest
+            platform: linux
+            arch: armhf
+            npm_config_arch: arm
+          - os: ubuntu-latest
+            platform: alpine
+            arch: x64
+            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: x64
+            npm_config_arch: x64
+          - os: macos-latest
+            platform: darwin
+            arch: arm64
+            npm_config_arch: arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+        env:
+          npm_config_arch: ${{ matrix.npm_config_arch }}
+      - shell: pwsh
+        run: echo "target=${{ matrix.platform }}-${{ matrix.arch }}" >> $env:GITHUB_ENV
+      - run: npx vsce package --target ${{ env.target }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.target }}
+          path: "*.vsix"
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - uses: actions/download-artifact@v3
+      - run: npx semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          # In case you want to publish to OpenVSX
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
 ```

--- a/README.md
+++ b/README.md
@@ -152,16 +152,16 @@ jobs:
    // package.release.config.js
    module.exports = {
      plugins: [
-       "@semantic-release/commit-analyzer",
-       "@semantic-release/release-notes-generator",
+       '@semantic-release/commit-analyzer',
+       '@semantic-release/release-notes-generator',
        [
-         "semantic-release-vsce",
+         'semantic-release-vsce',
          {
            packageVsix: true,
            publish: false, // no-op since we use semantic-release-stop-before-publish
          },
        ],
-       "semantic-release-stop-before-publish",
+       'semantic-release-stop-before-publish',
      ],
    };
    ```
@@ -172,19 +172,19 @@ jobs:
    // publish.release.config.js
    module.exports = {
      plugins: [
-       "@semantic-release/commit-analyzer",
-       "@semantic-release/release-notes-generator",
+       '@semantic-release/commit-analyzer',
+       '@semantic-release/release-notes-generator',
        [
-         "semantic-release-vsce",
+         'semantic-release-vsce',
          {
            packageVsix: false,
-           publishPackagePath: "*.vsix",
+           publishPackagePath: '*.vsix',
          },
        ],
        [
-         "@semantic-release/github",
+         '@semantic-release/github',
          {
-           assets: "*.vsix",
+           assets: '*.vsix',
          },
        ],
      ],
@@ -267,7 +267,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ env.target }}
-          path: "*.vsix"
+          path: '*.vsix'
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Whether to package or not the extension `.vsix`, or where to place it. This cont
 
 ### `publish`
 
-Whether to publish or not the extension to Visual Studio Marketplace. This controls if `vsce publish` gets called or not.
+Whether to publish or not the extension to Visual Studio Marketplace or OpenVSX (if the `OVSX_PAT` environment variable is present). This controls if `vsce publish` or `ovsx publish` (if the `OVSX_PAT` environment variable is present) gets called or not.
 
 | Value            | Description                                                    |
 | ---------------- | -------------------------------------------------------------- |
@@ -84,7 +84,7 @@ Which `.vsix` file (or files) to publish. This controls what value will be used 
 
 | Value              | Description                                                                                                       |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `"auto"` (default) | uses the `.vsix` packaged during the `prepare` step (if packaged)                                                 |
+| `"auto"` (default) | uses the `.vsix` packaged during the `prepare` step (if packaged), or behave as `false` otherwise                                                 |
 | `false`            | do not use a `.vsix` file to publish, which causes `vsce` to package the extension as part of the publish process |
 | a `string`         | publish the specified `.vsix` file(s). This can be a glob pattern, or a comma-separated list of files             |
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ async function publish (pluginConfig, { nextRelease: { version }, logger, cwd })
     packagePath = glob.sync(pluginConfig.publishPackagePath, { cwd });
   }
 
-  return vscePublish(version, packagePath, logger);
+  return vscePublish(version, packagePath, logger, cwd);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -8,21 +8,32 @@ let verified = false;
 let prepared = false;
 let packagePath;
 
-async function verifyConditions (pluginConfig, { logger, cwd }) {
+async function verifyConditions(pluginConfig, { logger, cwd }) {
   await verifyVsce(pluginConfig, { logger, cwd });
   verified = true;
 }
 
-async function prepare (pluginConfig, { nextRelease: { version }, logger, cwd }) {
+async function prepare(
+  pluginConfig,
+  { nextRelease: { version }, logger, cwd }
+) {
   if (!verified) {
     await verifyVsce(pluginConfig, { logger, cwd });
     verified = true;
   }
-  packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger, cwd);
+  packagePath = await vscePrepare(
+    version,
+    pluginConfig.packageVsix,
+    logger,
+    cwd
+  );
   prepared = true;
 }
 
-async function publish (pluginConfig, { nextRelease: { version }, logger, cwd }) {
+async function publish(
+  pluginConfig,
+  { nextRelease: { version }, logger, cwd }
+) {
   if (!verified) {
     await verifyVsce(pluginConfig, { logger, cwd });
     verified = true;
@@ -30,7 +41,12 @@ async function publish (pluginConfig, { nextRelease: { version }, logger, cwd })
 
   if (!prepared) {
     // BC: prior to semantic-release v15 prepare was part of publish
-    packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger, cwd);
+    packagePath = await vscePrepare(
+      version,
+      pluginConfig.packageVsix,
+      logger,
+      cwd
+    );
   }
 
   // If publishing is disabled, return early.
@@ -50,5 +66,5 @@ async function publish (pluginConfig, { nextRelease: { version }, logger, cwd })
 module.exports = {
   verifyConditions,
   prepare,
-  publish
+  publish,
 };

--- a/index.js
+++ b/index.js
@@ -38,6 +38,12 @@ async function publish (pluginConfig, { nextRelease: { version }, logger, cwd })
     return;
   }
 
+  if (pluginConfig?.publishPackagePath) {
+    // Expand glob
+    const glob = require('glob');
+    packagePath = glob.sync(pluginConfig.publishPackagePath, { cwd });
+  }
+
   return vscePublish(version, packagePath, logger);
 }
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -22,12 +22,19 @@ module.exports = async (version, packageVsix, logger, cwd) => {
       packagePath = packageVsix;
     } else {
       const { name } = await readJson('./package.json');
-      packagePath = `${name}-${version}.vsix`;
+      if (process.env.VSCE_TARGET) {
+        packagePath = `${name}-${process.env.VSCE_TARGET}-${version}.vsix`;
+      } else {
+        packagePath = `${name}-${version}.vsix`;
+      }
     }
 
     logger.log(`Packaging version ${version} to ${packagePath}`);
 
     const options = ['package', version, '--no-git-tag-version', '--out', packagePath];
+    if (process.env.VSCE_TARGET) {
+      options.push('--target', process.env.VSCE_TARGET);
+    }
 
     await execa('vsce', options, { stdio: 'inherit', preferLocal: true, cwd });
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -13,7 +13,9 @@ module.exports = async (version, packageVsix, logger, cwd) => {
 
   if (packageVsix || ovsxEnabled) {
     if (!packageVsix && ovsxEnabled) {
-      logger.log('Packaging to VSIX even though `packageVsix` is not set as publish to OpenVSX is enabled.');
+      logger.log(
+        'Packaging to VSIX even though `packageVsix` is not set as publish to OpenVSX is enabled.'
+      );
     }
 
     let packagePath;
@@ -31,7 +33,13 @@ module.exports = async (version, packageVsix, logger, cwd) => {
 
     logger.log(`Packaging version ${version} to ${packagePath}`);
 
-    const options = ['package', version, '--no-git-tag-version', '--out', packagePath];
+    const options = [
+      'package',
+      version,
+      '--no-git-tag-version',
+      '--out',
+      packagePath,
+    ];
     if (process.env.VSCE_TARGET) {
       options.push('--target', process.env.VSCE_TARGET);
     }

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,7 +2,7 @@
 
 const execa = require('execa');
 const { readJson } = require('fs-extra');
-const { isOvsxEnabled } = require('./verify-ovsx-auth');
+const { isOvsxEnabled, isTargetEnabled } = require('./utils');
 
 module.exports = async (version, packageVsix, logger, cwd) => {
   if (packageVsix === false) {
@@ -24,7 +24,7 @@ module.exports = async (version, packageVsix, logger, cwd) => {
       packagePath = packageVsix;
     } else {
       const { name } = await readJson('./package.json');
-      if (process.env.VSCE_TARGET) {
+      if (isTargetEnabled()) {
         packagePath = `${name}-${process.env.VSCE_TARGET}-${version}.vsix`;
       } else {
         packagePath = `${name}-${version}.vsix`;

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -5,7 +5,12 @@ const { readJson } = require('fs-extra');
 const { isOvsxEnabled } = require('./verify-ovsx-auth');
 
 module.exports = async (version, packageVsix, logger, cwd) => {
+  if (packageVsix === false) {
+    return;
+  }
+
   const ovsxEnabled = isOvsxEnabled();
+
   if (packageVsix || ovsxEnabled) {
     if (!packageVsix && ovsxEnabled) {
       logger.log('Packaging to VSIX even though `packageVsix` is not set as publish to OpenVSX is enabled.');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,12 +8,13 @@ module.exports = async (version, packagePath, logger, cwd) => {
   const { publisher, name } = await readJson('./package.json');
 
   const options = ['publish'];
-  // Ensure packagePath is a list
-  if (typeof packagePath === 'string') {
-    packagePath = [packagePath];
-  }
 
   if (packagePath) {
+    // Ensure packagePath is a list
+    if (typeof packagePath === 'string') {
+      packagePath = [packagePath];
+    }
+
     logger.log(`Publishing version ${version} from ${packagePath} to Visual Studio Marketplace`);
     options.push(...['--packagePath', ...packagePath]);
   } else {
@@ -34,7 +35,7 @@ module.exports = async (version, packagePath, logger, cwd) => {
   if (isOvsxEnabled()) {
     logger.log('Now publishing to OpenVSX');
 
-    await execa('ovsx', ['publish', ...packagePath], { stdio: 'inherit', preferLocal: true, cwd });
+    await execa('ovsx', options, { stdio: 'inherit', preferLocal: true, cwd });
     const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
 
     logger.log(`The new ovsx version is available at ${ovsxUrl}`);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,7 @@
 
 const execa = require('execa');
 const { readJson } = require('fs-extra');
-const { isOvsxEnabled } = require('./verify-ovsx-auth');
+const { isOvsxEnabled, isTargetEnabled } = require('./utils');
 
 module.exports = async (version, packagePath, logger, cwd) => {
   const { publisher, name } = await readJson('./package.json');
@@ -21,7 +21,8 @@ module.exports = async (version, packagePath, logger, cwd) => {
   } else {
     options.push(version, '--no-git-tag-version');
 
-    if (process.env.VSCE_TARGET) {
+    if (isTargetEnabled()) {
+      // @ts-ignore
       options.push('--target', process.env.VSCE_TARGET);
       message += ` for target ${process.env.VSCE_TARGET}`;
     }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -9,21 +9,25 @@ module.exports = async (version, packagePath, logger, cwd) => {
 
   const options = ['publish'];
 
+  let message = `Publishing version ${version}`;
   if (packagePath) {
     // Ensure packagePath is a list
     if (typeof packagePath === 'string') {
       packagePath = [packagePath];
     }
 
-    logger.log(`Publishing version ${version} from ${packagePath} to Visual Studio Marketplace`);
     options.push('--packagePath', ...packagePath);
+    message += ` from ${packagePath.join(', ')}`;
   } else {
+    options.push(version, '--no-git-tag-version');
+
     if (process.env.VSCE_TARGET) {
       options.push('--target', process.env.VSCE_TARGET);
+      message += ` for target ${process.env.VSCE_TARGET}`;
     }
-    logger.log(`Publishing version ${version} to Visual Studio Marketplace`);
-    options.push(version, '--no-git-tag-version');
   }
+  message += ' to Visual Studio Marketplace';
+  logger.log(message);
 
   await execa('vsce', options, { stdio: 'inherit', preferLocal: true, cwd });
 
@@ -32,12 +36,13 @@ module.exports = async (version, packagePath, logger, cwd) => {
 
   const vsceRelease = {
     name: 'Visual Studio Marketplace',
-    url: vsceUrl
+    url: vsceUrl,
   };
 
   if (isOvsxEnabled()) {
     logger.log('Now publishing to OpenVSX');
 
+    // When publishing to OpenVSX, packagePath will be always set
     await execa('ovsx', options, { stdio: 'inherit', preferLocal: true, cwd });
     const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,10 +8,14 @@ module.exports = async (version, packagePath, logger, cwd) => {
   const { publisher, name } = await readJson('./package.json');
 
   const options = ['publish'];
+  // Ensure packagePath is a list
+  if (typeof packagePath === 'string') {
+    packagePath = [packagePath];
+  }
 
   if (packagePath) {
     logger.log(`Publishing version ${version} from ${packagePath} to Visual Studio Marketplace`);
-    options.push(...['--packagePath', packagePath]);
+    options.push(...['--packagePath', ...packagePath]);
   } else {
     logger.log(`Publishing version ${version} to Visual Studio Marketplace`);
     options.push(...[version, '--no-git-tag-version']);
@@ -30,7 +34,7 @@ module.exports = async (version, packagePath, logger, cwd) => {
   if (isOvsxEnabled()) {
     logger.log('Now publishing to OpenVSX');
 
-    await execa('ovsx', ['publish', packagePath], { stdio: 'inherit', preferLocal: true, cwd });
+    await execa('ovsx', ['publish', ...packagePath], { stdio: 'inherit', preferLocal: true, cwd });
     const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
 
     logger.log(`The new ovsx version is available at ${ovsxUrl}`);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -16,10 +16,13 @@ module.exports = async (version, packagePath, logger, cwd) => {
     }
 
     logger.log(`Publishing version ${version} from ${packagePath} to Visual Studio Marketplace`);
-    options.push(...['--packagePath', ...packagePath]);
+    options.push('--packagePath', ...packagePath);
   } else {
+    if (process.env.VSCE_TARGET) {
+      options.push('--target', process.env.VSCE_TARGET);
+    }
     logger.log(`Publishing version ${version} to Visual Studio Marketplace`);
-    options.push(...[version, '--no-git-tag-version']);
+    options.push(version, '--no-git-tag-version');
   }
 
   await execa('vsce', options, { stdio: 'inherit', preferLocal: true, cwd });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,12 @@
+const isOvsxEnabled = () => {
+  return 'OVSX_PAT' in process.env;
+};
+
+const isTargetEnabled = () => {
+  return 'VSCE_TARGET' in process.env;
+};
+
+module.exports = {
+  isTargetEnabled,
+  isOvsxEnabled,
+};

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -7,12 +7,18 @@ module.exports = async (logger, cwd) => {
   logger.log('Verifying authentication for vsce');
 
   if (!process.env.VSCE_PAT) {
-    throw new SemanticReleaseError('No vsce personal access token specified (set the `VSCE_PAT` environment variable).', 'ENOVSCEPAT');
+    throw new SemanticReleaseError(
+      'No vsce personal access token specified (set the `VSCE_PAT` environment variable).',
+      'ENOVSCEPAT'
+    );
   }
 
   try {
     await execa('vsce', ['verify-pat'], { preferLocal: true, cwd });
   } catch (e) {
-    throw new SemanticReleaseError(`Invalid vsce token. Additional information:\n\n${e}`, 'EINVALIDVSCETOKEN');
+    throw new SemanticReleaseError(
+      `Invalid vsce token. Additional information:\n\n${e}`,
+      'EINVALIDVSCETOKEN'
+    );
   }
 };

--- a/lib/verify-ovsx-auth.js
+++ b/lib/verify-ovsx-auth.js
@@ -10,12 +10,17 @@ module.exports = async (logger) => {
   logger.log('Verifying authentication for ovsx');
 
   if (!isOvsxEnabled()) {
-    logger.log('Skipping verification of ovsx personal token because the `OVSX_PAT` environment variable is not set.\n\nDid you know you can easily start publishing to OpenVSX with `semantic-release-vsce`?\nLearn more at https://github.com/felipecrs/semantic-release-vsce#publishing-to-openvsx');
+    logger.log(
+      'Skipping verification of ovsx personal token because the `OVSX_PAT` environment variable is not set.\n\nDid you know you can easily start publishing to OpenVSX with `semantic-release-vsce`?\nLearn more at https://github.com/felipecrs/semantic-release-vsce#publishing-to-openvsx'
+    );
     return;
   }
 
   if (!process.env.OVSX_PAT) {
-    throw new SemanticReleaseError('Empty ovsx personal access token specified.', 'EINVALIDOVSXPAT');
+    throw new SemanticReleaseError(
+      'Empty ovsx personal access token specified.',
+      'EINVALIDOVSXPAT'
+    );
   }
 
   // TODO: waiting for https://github.com/eclipse/openvsx/issues/313

--- a/lib/verify-ovsx-auth.js
+++ b/lib/verify-ovsx-auth.js
@@ -1,10 +1,7 @@
 // @ts-check
 
 const SemanticReleaseError = require('@semantic-release/error');
-
-const isOvsxEnabled = () => {
-  return 'OVSX_PAT' in process.env;
-};
+const { isOvsxEnabled } = require('./utils');
 
 module.exports = async (logger) => {
   logger.log('Verifying authentication for ovsx');
@@ -30,5 +27,3 @@ module.exports = async (logger) => {
   //   throw new SemanticReleaseError(`Invalid ovsx personal access token. Additional information:\n\n${e}`, 'EINVALIDOVSXPAT');
   // }
 };
-
-module.exports.isOvsxEnabled = isOvsxEnabled;

--- a/lib/verify-pkg.js
+++ b/lib/verify-pkg.js
@@ -17,15 +17,24 @@ module.exports = async () => {
   try {
     packageJson = await readJson('./package.json');
   } catch (error) {
-    throw new SemanticReleaseError('The `package.json` seems to be invalid.', 'EINVALIDPKG');
+    throw new SemanticReleaseError(
+      'The `package.json` seems to be invalid.',
+      'EINVALIDPKG'
+    );
   }
 
   const { name, publisher } = packageJson;
 
   if (!name) {
-    throw new SemanticReleaseError('No `name` found in `package.json`.', 'ENOPKGNAME');
+    throw new SemanticReleaseError(
+      'No `name` found in `package.json`.',
+      'ENOPKGNAME'
+    );
   }
   if (!publisher) {
-    throw new SemanticReleaseError('No `publisher` found in `package.json`.', 'ENOPUBLISHER');
+    throw new SemanticReleaseError(
+      'No `publisher` found in `package.json`.',
+      'ENOPUBLISHER'
+    );
   }
 };

--- a/lib/verify-target.js
+++ b/lib/verify-target.js
@@ -1,0 +1,29 @@
+// @ts-check
+
+const SemanticReleaseError = require('@semantic-release/error');
+const { isTargetEnabled } = require('./utils');
+
+module.exports = async () => {
+  if (!isTargetEnabled()) {
+    return;
+  }
+
+  if (!process.env.VSCE_TARGET) {
+    throw new SemanticReleaseError(
+      'Empty vsce target specified.',
+      'EINVALIDVSCETARGET'
+    );
+  }
+
+  const targets = require('vsce/out/package').Targets;
+
+  // Throw if the target is not supported
+  if (!targets.has(process.env.VSCE_TARGET)) {
+    throw new SemanticReleaseError(
+      `Unsupported vsce target: ${
+        process.env.VSCE_TARGET
+      }. Available targets: ${Object.values(targets).join(', ')}`,
+      'EUNSUPPORTEDVSCETARGET'
+    );
+  }
+};

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -3,9 +3,19 @@
 const verifyPkg = require('./verify-pkg');
 const verifyAuth = require('./verify-auth');
 const verifyOvsxAuth = require('./verify-ovsx-auth');
+const SemanticReleaseError = require('@semantic-release/error');
 
 module.exports = async (pluginConfig, { logger, cwd }) => {
   await verifyPkg();
+
+  if (process.env.VSCE_TARGET) {
+    const targets = require('vsce/out/package').Targets;
+
+    // Throw if the target is not supported
+    if (!targets.has(process.env.VSCE_TARGET)) {
+      throw new SemanticReleaseError(`Unsupported VSCE_TARGET: ${process.env.VSCE_TARGET}. Available targets: ${Object.values(targets).join(', ')}`, 'EINVALIDVSCETARGET');
+    }
+  }
 
   if (pluginConfig?.publish !== false) {
     await verifyAuth(logger, cwd);

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -13,7 +13,12 @@ module.exports = async (pluginConfig, { logger, cwd }) => {
 
     // Throw if the target is not supported
     if (!targets.has(process.env.VSCE_TARGET)) {
-      throw new SemanticReleaseError(`Unsupported VSCE_TARGET: ${process.env.VSCE_TARGET}. Available targets: ${Object.values(targets).join(', ')}`, 'EINVALIDVSCETARGET');
+      throw new SemanticReleaseError(
+        `Unsupported VSCE_TARGET: ${
+          process.env.VSCE_TARGET
+        }. Available targets: ${Object.values(targets).join(', ')}`,
+        'EINVALIDVSCETARGET'
+      );
     }
   }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -3,24 +3,11 @@
 const verifyPkg = require('./verify-pkg');
 const verifyAuth = require('./verify-auth');
 const verifyOvsxAuth = require('./verify-ovsx-auth');
-const SemanticReleaseError = require('@semantic-release/error');
+const verifyTarget = require('./verify-target');
 
 module.exports = async (pluginConfig, { logger, cwd }) => {
   await verifyPkg();
-
-  if (process.env.VSCE_TARGET) {
-    const targets = require('vsce/out/package').Targets;
-
-    // Throw if the target is not supported
-    if (!targets.has(process.env.VSCE_TARGET)) {
-      throw new SemanticReleaseError(
-        `Unsupported VSCE_TARGET: ${
-          process.env.VSCE_TARGET
-        }. Available targets: ${Object.values(targets).join(', ')}`,
-        'EINVALIDVSCETARGET'
-      );
-    }
-  }
+  await verifyTarget();
 
   if (pluginConfig?.publish !== false) {
     await verifyAuth(logger, cwd);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@semantic-release/error": "^3.0.0",
         "execa": "^5.0.0",
         "fs-extra": "^10.0.0",
+        "glob": "^8.0.3",
         "ovsx": "^0.5.0",
         "vsce": "^2.6.3"
       },
@@ -4279,19 +4280,18 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": "*"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4307,6 +4307,25 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/global-dirs": {
@@ -8709,6 +8728,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/nyc/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/nyc/node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -10036,6 +10075,25 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11047,6 +11105,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -11498,6 +11576,25 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vsce/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/vsce/node_modules/has-flag": {
@@ -15190,16 +15287,33 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "glob-parent": {
@@ -18358,6 +18472,20 @@
             "path-exists": "^4.0.0"
           }
         },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "indent-string": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -19310,6 +19438,21 @@
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "requires": {
         "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "run-parallel": {
@@ -20062,6 +20205,22 @@
         "@istanbuljs/schema": "^0.1.2",
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "text-extensions": {
@@ -20412,6 +20571,19 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "has-flag": {
           "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,17 +17,18 @@
         "vsce": "^2.6.3"
       },
       "devDependencies": {
-        "@commitlint/cli": "^17.0.0",
-        "@commitlint/config-conventional": "^17.0.0",
         "ava": "^5.0.1",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "eslint": "^8.7.0",
+        "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.20.1",
         "eslint-plugin-n": "^15.2.1",
         "eslint-plugin-promise": "^6.0.0",
-        "husky": "^8.0.1",
+        "husky": "^8.0.2",
+        "lint-staged": "^13.0.3",
         "nyc": "^15.1.0",
+        "prettier": "2.7.1",
         "proxyquire": "^2.1.3",
         "semantic-release": "^19.0.2",
         "sinon": "^14.0.0"
@@ -435,290 +436,6 @@
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
-      }
-    },
-    "node_modules/@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
-        "@commitlint/read": "^17.2.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0",
-        "yargs": "^17.0.0"
-      },
-      "bin": {
-        "commitlint": "cli.js"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
-      "dev": true,
-      "dependencies": {
-        "conventional-changelog-conventionalcommits": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-validator": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
-      "integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "ajv": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@commitlint/config-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/is-ignored": "^17.2.0",
-        "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
-        "@commitlint/types": "^17.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": "^14.0.0",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
-        "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "ts-node": "^10.8.1",
-        "typescript": "^4.6.4"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/message": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.2.0.tgz",
-      "integrity": "sha512-/4l2KFKxBOuoEn1YAuuNNlAU05Zt7sNsC9H0mPdPm3chOrT4rcX0pOqrQcLtdMrMkJz0gC7b3SF80q2+LtdL9Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/parse": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.2.0.tgz",
-      "integrity": "sha512-vLzLznK9Y21zQ6F9hf8D6kcIJRb2haAK5T/Vt1uW2CbHYOIfNsR/hJs0XnF/J9ctM20Tfsqv4zBitbYvVw7F6Q==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "conventional-changelog-angular": "^5.0.11",
-        "conventional-commits-parser": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/read": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.2.0.tgz",
-      "integrity": "sha512-bbblBhrHkjxra3ptJNm0abxu7yeAaxumQ8ZtD6GIVqzURCETCP7Dm0tlVvGRDyXBuqX6lIJxh3W7oyKqllDsHQ==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
-        "git-raw-commits": "^2.0.0",
-        "minimist": "^1.2.6"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
-      "dev": true,
-      "dependencies": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.2.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=v14"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1341,30 +1058,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
-    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1375,12 +1068,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "14.18.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1577,12 +1264,6 @@
         "readable-stream": "^2.0.6"
       }
     },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1674,6 +1355,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ava": {
@@ -2293,6 +1983,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cli-table3": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
@@ -2467,6 +2169,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
     },
     "node_modules/commander": {
       "version": "6.2.1",
@@ -2658,28 +2366,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig-typescript-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
-      "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@types/node": "*",
-        "cosmiconfig": ">=7",
-        "ts-node": ">=10",
-        "typescript": ">=3"
-      }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2738,15 +2424,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/date-time": {
@@ -3308,6 +2985,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -4255,25 +3944,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/git-raw-commits": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
-      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
-      "dev": true,
-      "dependencies": {
-        "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      },
-      "bin": {
-        "git-raw-commits": "cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -4326,18 +3996,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "dev": true,
-      "dependencies": {
-        "ini": "^1.3.4"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/globals": {
@@ -5477,6 +5135,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5489,6 +5156,338 @@
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "dependencies": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lint-staged": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
+      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.17",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4",
+        "execa": "^6.1.0",
+        "lilconfig": "2.0.5",
+        "listr2": "^4.0.5",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-inspect": "^1.12.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.1",
+        "yaml": "^2.1.1"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/lint-staged/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/listr2/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/listr2/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/listr2/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/load-json-file": {
@@ -5578,6 +5577,165 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
+    "node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-update/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-update/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5612,12 +5770,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
@@ -9361,6 +9513,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true,
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -9580,6 +9744,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {
@@ -9977,15 +10156,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -10030,13 +10200,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "dependencies": {
-        "global-dirs": "^0.1.1"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       },
       "engines": {
         "node": ">=8"
@@ -10060,6 +10231,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -10115,6 +10292,15 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -10837,6 +11023,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -11231,58 +11426,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -11392,19 +11535,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -11496,12 +11626,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12051,15 +12175,6 @@
         "buffer-crc32": "~0.2.3"
       }
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12378,233 +12493,6 @@
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
       "optional": true
-    },
-    "@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
-      "dev": true,
-      "requires": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
-        "@commitlint/read": "^17.2.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "5.0.0",
-        "resolve-global": "1.0.0",
-        "yargs": "^17.0.0"
-      }
-    },
-    "@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
-      "dev": true,
-      "requires": {
-        "conventional-changelog-conventionalcommits": "^5.0.0"
-      }
-    },
-    "@commitlint/config-validator": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
-      "integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "ajv": "^8.11.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        }
-      }
-    },
-    "@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
-      }
-    },
-    "@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
-      "dev": true
-    },
-    "@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "chalk": "^4.1.0"
-      }
-    },
-    "@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
-      }
-    },
-    "@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
-      "dev": true,
-      "requires": {
-        "@commitlint/is-ignored": "^17.2.0",
-        "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
-        "@commitlint/types": "^17.0.0"
-      }
-    },
-    "@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
-      "dev": true,
-      "requires": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": "^14.0.0",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
-        "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "ts-node": "^10.8.1",
-        "typescript": "^4.6.4"
-      }
-    },
-    "@commitlint/message": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.2.0.tgz",
-      "integrity": "sha512-/4l2KFKxBOuoEn1YAuuNNlAU05Zt7sNsC9H0mPdPm3chOrT4rcX0pOqrQcLtdMrMkJz0gC7b3SF80q2+LtdL9Q==",
-      "dev": true
-    },
-    "@commitlint/parse": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.2.0.tgz",
-      "integrity": "sha512-vLzLznK9Y21zQ6F9hf8D6kcIJRb2haAK5T/Vt1uW2CbHYOIfNsR/hJs0XnF/J9ctM20Tfsqv4zBitbYvVw7F6Q==",
-      "dev": true,
-      "requires": {
-        "@commitlint/types": "^17.0.0",
-        "conventional-changelog-angular": "^5.0.11",
-        "conventional-commits-parser": "^3.2.2"
-      }
-    },
-    "@commitlint/read": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.2.0.tgz",
-      "integrity": "sha512-bbblBhrHkjxra3ptJNm0abxu7yeAaxumQ8ZtD6GIVqzURCETCP7Dm0tlVvGRDyXBuqX6lIJxh3W7oyKqllDsHQ==",
-      "dev": true,
-      "requires": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
-        "git-raw-commits": "^2.0.0",
-        "minimist": "^1.2.6"
-      }
-    },
-    "@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
-      "dev": true,
-      "requires": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
-        "resolve-from": "^5.0.0",
-        "resolve-global": "^1.0.0"
-      }
-    },
-    "@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
-      "dev": true,
-      "requires": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.2.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "execa": "^5.0.0"
-      }
-    },
-    "@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
-      "dev": true
-    },
-    "@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^5.0.0"
-      }
-    },
-    "@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0"
-      }
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "dependencies": {
-        "@jridgewell/trace-mapping": {
-          "version": "0.3.9",
-          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/resolve-uri": "^3.0.3",
-            "@jridgewell/sourcemap-codec": "^1.4.10"
-          }
-        }
-      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -13114,30 +13002,6 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
-    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -13148,12 +13012,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "14.18.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -13298,12 +13156,6 @@
         "readable-stream": "^2.0.6"
       }
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -13368,6 +13220,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
       "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "ava": {
@@ -13806,6 +13664,15 @@
       "integrity": "sha512-3yONmlN9CSAkzNwnRCiJQ7Q2xK5mWuEfL3PuTZcAUzhObbXsfsnMptJzXwz93nc5zn9V9TwCVMmV7w4xsm43dw==",
       "dev": true
     },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
     "cli-table3": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.2.tgz",
@@ -13943,6 +13810,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+      "dev": true
     },
     "commander": {
       "version": "6.2.1",
@@ -14100,19 +13973,6 @@
         "yaml": "^1.10.0"
       }
     },
-    "cosmiconfig-typescript-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
-      "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-      "dev": true,
-      "requires": {}
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -14154,12 +14014,6 @@
       "requires": {
         "array-find-index": "^1.0.1"
       }
-    },
-    "dargs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-      "dev": true
     },
     "date-time": {
       "version": "3.1.0",
@@ -14607,6 +14461,13 @@
           }
         }
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "17.0.0",
@@ -15268,19 +15129,6 @@
         }
       }
     },
-    "git-raw-commits": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
-      "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
-      "dev": true,
-      "requires": {
-        "dargs": "^7.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
-      }
-    },
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -15323,15 +15171,6 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
-      }
-    },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4"
       }
     },
     "globals": {
@@ -16136,6 +15975,12 @@
         "type-check": "~0.4.0"
       }
     },
+    "lilconfig": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -16148,6 +15993,232 @@
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
       "requires": {
         "uc.micro": "^1.0.1"
+      }
+    },
+    "lint-staged": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
+      "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^3.1.0",
+        "colorette": "^2.0.17",
+        "commander": "^9.3.0",
+        "debug": "^4.3.4",
+        "execa": "^6.1.0",
+        "lilconfig": "2.0.5",
+        "listr2": "^4.0.5",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-inspect": "^1.12.2",
+        "pidtree": "^0.6.0",
+        "string-argv": "^0.3.1",
+        "yaml": "^2.1.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+          "dev": true
+        },
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+          "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+          "dev": true
+        }
+      }
+    },
+    "listr2": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+      "dev": true,
+      "requires": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.16",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.5.5",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "aggregate-error": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+          "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^2.0.0",
+            "indent-string": "^4.0.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "clean-stack": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+          "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+          "dev": true
+        },
+        "cli-truncate": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+          "dev": true,
+          "requires": {
+            "slice-ansi": "^3.0.0",
+            "string-width": "^4.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "p-map": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -16225,6 +16296,119 @@
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
+    "log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
+      }
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -16249,12 +16433,6 @@
           "dev": true
         }
       }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -18931,6 +19109,12 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "pidtree": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "dev": true
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -19079,6 +19263,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "pretty-ms": {
@@ -19373,12 +19563,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
-    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -19411,13 +19595,14 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
-    "resolve-global": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
-      "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.1"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "retry": {
@@ -19430,6 +19615,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
     "rimraf": {
@@ -19462,6 +19653,15 @@
       "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -20008,6 +20208,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -20310,35 +20516,6 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -20426,12 +20603,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true
-    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -20504,12 +20675,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -20935,12 +21100,6 @@
       "requires": {
         "buffer-crc32": "~0.2.3"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@semantic-release/error": "^3.0.0",
     "execa": "^5.0.0",
     "fs-extra": "^10.0.0",
+    "glob": "^8.0.3",
     "ovsx": "^0.5.0",
     "vsce": "^2.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "prettier --check . && eslint .",
     "release": "semantic-release",
     "test": "nyc ava",
     "posttest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "bugs": "https://github.com/felipecrs/semantic-release-vsce/issues",
   "homepage": "https://github.com/felipecrs/semantic-release-vsce#readme",
   "author": "Morten Henriksen <mh@gi2.dk>",
+  "contributors": [
+    "Felipe Santos <felipecassiors@gmail.com>"
+  ],
   "keywords": [
     "semantic-release",
     "semantic-release-plugin",
@@ -27,11 +30,6 @@
   "ava": {
     "files": [
       "test/**/*.test.js"
-    ]
-  },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
     ]
   },
   "nyc": {
@@ -60,19 +58,23 @@
     "semantic-release": ">=18"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.0.0",
-    "@commitlint/config-conventional": "^17.0.0",
     "ava": "^5.0.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.7.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-promise": "^6.0.0",
-    "husky": "^8.0.1",
+    "husky": "^8.0.2",
+    "lint-staged": "^13.0.3",
     "nyc": "^15.1.0",
+    "prettier": "2.7.1",
     "proxyquire": "^2.1.3",
     "semantic-release": "^19.0.2",
     "sinon": "^14.0.0"
+  },
+  "lint-staged": {
+    "**/*": "prettier --write --ignore-unknown"
   }
 }

--- a/release.config.js
+++ b/release.config.js
@@ -6,19 +6,19 @@ module.exports = {
         releaseRules: [
           {
             type: 'perf',
-            release: 'patch'
+            release: 'patch',
           },
           {
             type: 'refactor',
-            release: 'patch'
+            release: 'patch',
           },
           {
             type: 'build',
             scope: 'deps',
-            release: 'patch'
-          }
-        ]
-      }
+            release: 'patch',
+          },
+        ],
+      },
     ],
     [
       '@semantic-release/release-notes-generator',
@@ -27,40 +27,40 @@ module.exports = {
           types: [
             {
               type: 'feat',
-              section: 'Features'
+              section: 'Features',
             },
             {
               type: 'fix',
-              section: 'Bug Fixes'
+              section: 'Bug Fixes',
             },
             {
               type: 'perf',
-              section: 'Performance Improvements'
+              section: 'Performance Improvements',
             },
             {
               type: 'revert',
-              section: 'Reverts'
+              section: 'Reverts',
             },
             {
               type: 'refactor',
-              section: 'Code Refactoring'
+              section: 'Code Refactoring',
             },
             {
               type: 'build',
               scope: 'deps',
-              section: 'Dependencies'
-            }
-          ]
-        }
-      }
+              section: 'Dependencies',
+            },
+          ],
+        },
+      },
     ],
     '@semantic-release/npm',
     [
       '@semantic-release/github',
       {
-        addReleases: 'bottom'
-      }
-    ]
+        addReleases: 'bottom',
+      },
+    ],
   ],
-  preset: 'conventionalcommits'
+  preset: 'conventionalcommits',
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,71 +4,81 @@ const proxyquire = require('proxyquire');
 
 const semanticReleasePayload = {
   nextRelease: {
-    version: '1.0.0'
+    version: '1.0.0',
   },
   logger: {
-    log: sinon.fake()
+    log: sinon.fake(),
   },
-  cwd: process.cwd()
+  cwd: process.cwd(),
 };
 
 const pluginConfig = {
-  packageVsix: 'test.vsix'
+  packageVsix: 'test.vsix',
 };
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   t.context.stubs = {
     verifyVsceStub: sinon.stub().resolves(),
     vscePublishStub: sinon.stub().resolves(),
-    vscePrepareStub: sinon.stub().resolves()
+    vscePrepareStub: sinon.stub().resolves(),
   };
 });
 
-test.afterEach(t => {
-  Object.keys(t.context.stubs).forEach(key => {
+test.afterEach((t) => {
+  Object.keys(t.context.stubs).forEach((key) => {
     t.context.stubs[key].resetHistory();
   });
 });
 
-test('verifyConditions', async t => {
+test('verifyConditions', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { verifyConditions } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
   await verifyConditions(pluginConfig, semanticReleasePayload);
 
-  t.true(verifyVsceStub.calledOnceWith(pluginConfig, { logger: semanticReleasePayload.logger, cwd: semanticReleasePayload.cwd }));
+  t.true(
+    verifyVsceStub.calledOnceWith(pluginConfig, {
+      logger: semanticReleasePayload.logger,
+      cwd: semanticReleasePayload.cwd,
+    })
+  );
 });
 
-test('prepare and unverified', async t => {
+test('prepare and unverified', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { prepare } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
     './lib/prepare': vscePrepareStub,
-    verified: false
+    verified: false,
   });
 
   await prepare(pluginConfig, semanticReleasePayload);
 
-  t.true(verifyVsceStub.calledOnceWith(pluginConfig, { logger: semanticReleasePayload.logger, cwd: semanticReleasePayload.cwd }));
+  t.true(
+    verifyVsceStub.calledOnceWith(pluginConfig, {
+      logger: semanticReleasePayload.logger,
+      cwd: semanticReleasePayload.cwd,
+    })
+  );
   t.deepEqual(vscePrepareStub.getCall(0).args, [
     semanticReleasePayload.nextRelease.version,
     pluginConfig.packageVsix,
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });
 
-test('prepare and verified', async t => {
+test('prepare and verified', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { prepare, verifyConditions } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
   await verifyConditions(pluginConfig, semanticReleasePayload);
@@ -79,16 +89,16 @@ test('prepare and verified', async t => {
     semanticReleasePayload.nextRelease.version,
     pluginConfig.packageVsix,
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });
 
-test('publish that is unverified and unprepared', async t => {
+test('publish that is unverified and unprepared', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { publish } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
   await publish(pluginConfig, semanticReleasePayload);
@@ -99,16 +109,16 @@ test('publish that is unverified and unprepared', async t => {
     semanticReleasePayload.nextRelease.version,
     undefined,
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });
 
-test('publish that is verified but unprepared', async t => {
+test('publish that is verified but unprepared', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { publish, verifyConditions } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
   await verifyConditions(pluginConfig, semanticReleasePayload);
@@ -120,16 +130,16 @@ test('publish that is verified but unprepared', async t => {
     semanticReleasePayload.nextRelease.version,
     undefined,
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });
 
-test('publish that is already verified & prepared', async t => {
+test('publish that is already verified & prepared', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { prepare, publish, verifyConditions } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
   await verifyConditions(pluginConfig, semanticReleasePayload);
@@ -142,39 +152,42 @@ test('publish that is already verified & prepared', async t => {
     semanticReleasePayload.nextRelease.version,
     packagePath,
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });
 
-test('it does not publish the package if publishing is disabled', async t => {
+test('it does not publish the package if publishing is disabled', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { prepare, publish, verifyConditions } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
-    './lib/prepare': vscePrepareStub
+    './lib/prepare': vscePrepareStub,
   });
 
-  await verifyConditions({ ...pluginConfig, publish: false }, semanticReleasePayload);
+  await verifyConditions(
+    { ...pluginConfig, publish: false },
+    semanticReleasePayload
+  );
   await prepare({ ...pluginConfig, publish: false }, semanticReleasePayload);
   await publish({ ...pluginConfig, publish: false }, semanticReleasePayload);
 
   t.true(vscePublishStub.notCalled);
 });
 
-test('expand globs if publishPackagePath is set', async t => {
+test('expand globs if publishPackagePath is set', async (t) => {
   const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
   const { publish } = proxyquire('../index.js', {
     './lib/verify': verifyVsceStub,
     './lib/publish': vscePublishStub,
     './lib/prepare': vscePrepareStub,
     glob: {
-      sync: sinon.stub().returns(['package1.vsix', 'package2.vsix'])
-    }
+      sync: sinon.stub().returns(['package1.vsix', 'package2.vsix']),
+    },
   });
 
   const pluginConfig = {
     publishPackagePath: 'package*.vsix',
-    packageVsix: false
+    packageVsix: false,
   };
 
   await publish(pluginConfig, semanticReleasePayload);
@@ -185,6 +198,6 @@ test('expand globs if publishPackagePath is set', async t => {
     semanticReleasePayload.nextRelease.version,
     ['package1.vsix', 'package2.vsix'],
     semanticReleasePayload.logger,
-    semanticReleasePayload.cwd
+    semanticReleasePayload.cwd,
   ]);
 });

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -3,24 +3,24 @@ const test = require('ava');
 const proxyquire = require('proxyquire');
 
 const logger = {
-  log: sinon.fake()
+  log: sinon.fake(),
 };
 const cwd = process.cwd();
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   t.context.stubs = {
-    execaStub: sinon.stub()
+    execaStub: sinon.stub(),
   };
 });
 
-test.afterEach(t => {
+test.afterEach((t) => {
   t.context.stubs.execaStub.resetHistory();
 });
 
-test('packageVsix is not specified', async t => {
+test('packageVsix is not specified', async (t) => {
   const { execaStub } = t.context.stubs;
   const prepare = proxyquire('../lib/prepare', {
-    execa: execaStub
+    execa: execaStub,
   });
 
   const version = '1.0.0';
@@ -29,10 +29,10 @@ test('packageVsix is not specified', async t => {
   t.true(execaStub.notCalled);
 });
 
-test('packageVsix is a string', async t => {
+test('packageVsix is a string', async (t) => {
   const { execaStub } = t.context.stubs;
   const prepare = proxyquire('../lib/prepare', {
-    execa: execaStub
+    execa: execaStub,
   });
 
   const version = '1.0.0';
@@ -41,10 +41,14 @@ test('packageVsix is a string', async t => {
   const result = await prepare(version, packageVsix, logger, cwd);
 
   t.deepEqual(result, packagePath);
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['package', version, '--no-git-tag-version', '--out', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });
 
-test('packageVsix is true', async t => {
+test('packageVsix is true', async (t) => {
   const { execaStub } = t.context.stubs;
   const name = 'test';
 
@@ -52,9 +56,9 @@ test('packageVsix is true', async t => {
     execa: execaStub,
     'fs-extra': {
       readJson: sinon.stub().returns({
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   const version = '1.0.0';
@@ -64,10 +68,14 @@ test('packageVsix is true', async t => {
   const result = await prepare(version, packageVsix, logger, cwd);
 
   t.deepEqual(result, packagePath);
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['package', version, '--no-git-tag-version', '--out', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });
 
-test('packageVsix is not set but OVSX_PAT is', async t => {
+test('packageVsix is not set but OVSX_PAT is', async (t) => {
   const { execaStub } = t.context.stubs;
   const name = 'test';
 
@@ -75,13 +83,13 @@ test('packageVsix is not set but OVSX_PAT is', async t => {
     execa: execaStub,
     'fs-extra': {
       readJson: sinon.stub().returns({
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   sinon.stub(process, 'env').value({
-    OVSX_PAT: 'abc123'
+    OVSX_PAT: 'abc123',
   });
 
   const version = '1.0.0';
@@ -91,5 +99,9 @@ test('packageVsix is not set but OVSX_PAT is', async t => {
   const result = await prepare(version, packageVsix, logger, cwd);
 
   t.deepEqual(result, packagePath);
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['package', version, '--no-git-tag-version', '--out', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['package', version, '--no-git-tag-version', '--out', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -3,21 +3,21 @@ const test = require('ava');
 const proxyquire = require('proxyquire');
 
 const logger = {
-  log: sinon.fake()
+  log: sinon.fake(),
 };
 const cwd = process.cwd();
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   t.context.stubs = {
-    execaStub: sinon.stub()
+    execaStub: sinon.stub(),
   };
 });
 
-test.afterEach(t => {
+test.afterEach((t) => {
   t.context.stubs.execaStub.resetHistory();
 });
 
-test('publish', async t => {
+test('publish', async (t) => {
   const { execaStub } = t.context.stubs;
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
@@ -26,26 +26,30 @@ test('publish', async t => {
     'fs-extra': {
       readJson: sinon.stub().returns({
         publisher,
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   const version = '1.0.0';
   const token = 'abc123';
   sinon.stub(process, 'env').value({
-    VSCE_PAT: token
+    VSCE_PAT: token,
   });
   const result = await publish(version, undefined, logger, cwd);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
-    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
+    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', version, '--no-git-tag-version'], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['publish', version, '--no-git-tag-version'],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });
 
-test('publish with packagePath', async t => {
+test('publish with packagePath', async (t) => {
   const { execaStub } = t.context.stubs;
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
@@ -54,27 +58,31 @@ test('publish with packagePath', async t => {
     'fs-extra': {
       readJson: sinon.stub().returns({
         publisher,
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   const version = '1.0.0';
   const packagePath = 'test.vsix';
   const token = 'abc123';
   sinon.stub(process, 'env').value({
-    VSCE_PAT: token
+    VSCE_PAT: token,
   });
   const result = await publish(version, packagePath, logger, cwd);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
-    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
+    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--packagePath', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['publish', '--packagePath', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });
 
-test('publish to OpenVSX', async t => {
+test('publish to OpenVSX', async (t) => {
   const { execaStub } = t.context.stubs;
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
@@ -83,9 +91,9 @@ test('publish to OpenVSX', async t => {
     'fs-extra': {
       readJson: sinon.stub().returns({
         publisher,
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   const version = '1.0.0';
@@ -93,19 +101,27 @@ test('publish to OpenVSX', async t => {
   const token = 'abc123';
   sinon.stub(process, 'env').value({
     OVSX_PAT: token,
-    VSCE_PAT: token
+    VSCE_PAT: token,
   });
   const result = await publish(version, packagePath, logger, cwd);
 
   t.deepEqual(result, {
     name: 'Visual Studio Marketplace',
-    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`
+    url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, ['vsce', ['publish', '--packagePath', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(0).args, [
+    'vsce',
+    ['publish', '--packagePath', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 
   // t.deepEqual(result[1], {
   //   name: 'Open VSX Registry',
   //   url: `https://open-vsx.org/extension/${publisher}/${name}/${version}`
   // });
-  t.deepEqual(execaStub.getCall(1).args, ['ovsx', ['publish', '--packagePath', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(1).args, [
+    'ovsx',
+    ['publish', '--packagePath', packagePath],
+    { stdio: 'inherit', preferLocal: true, cwd },
+  ]);
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -107,5 +107,5 @@ test('publish to OpenVSX', async t => {
   //   name: 'Open VSX Registry',
   //   url: `https://open-vsx.org/extension/${publisher}/${name}/${version}`
   // });
-  t.deepEqual(execaStub.getCall(1).args, ['ovsx', ['publish', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
+  t.deepEqual(execaStub.getCall(1).args, ['ovsx', ['publish', '--packagePath', packagePath], { stdio: 'inherit', preferLocal: true, cwd }]);
 });

--- a/test/verify-auth.test.js
+++ b/test/verify-auth.test.js
@@ -4,52 +4,70 @@ const proxyquire = require('proxyquire');
 const SemanticReleaseError = require('@semantic-release/error');
 
 const logger = {
-  log: sinon.fake()
+  log: sinon.fake(),
 };
 const cwd = process.cwd();
 
-test('VSCE_PAT is set', async t => {
+test('VSCE_PAT is set', async (t) => {
   sinon.stub(process, 'env').value({
-    VSCE_PAT: 'abc123'
+    VSCE_PAT: 'abc123',
   });
 
   const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd }).resolves()
+    execa: sinon
+      .stub()
+      .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+      .resolves(),
   });
 
   await t.notThrowsAsync(() => verifyAuth(logger));
 });
 
-test('VSCE_PAT is not set', async t => {
+test('VSCE_PAT is not set', async (t) => {
   sinon.stub(process, 'env').value({});
 
   const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd }).resolves()
+    execa: sinon
+      .stub()
+      .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+      .resolves(),
   });
 
-  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'ENOVSCEPAT' });
+  await t.throwsAsync(() => verifyAuth(logger), {
+    instanceOf: SemanticReleaseError,
+    code: 'ENOVSCEPAT',
+  });
 });
 
-test('VSCE_PAT is valid', async t => {
+test('VSCE_PAT is valid', async (t) => {
   sinon.stub(process, 'env').value({
-    VSCE_PAT: 'abc123'
+    VSCE_PAT: 'abc123',
   });
 
   const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd }).resolves()
+    execa: sinon
+      .stub()
+      .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+      .resolves(),
   });
 
   await t.notThrowsAsync(() => verifyAuth(logger));
 });
 
-test('VSCE_PAT is invalid', async t => {
+test('VSCE_PAT is invalid', async (t) => {
   sinon.stub(process, 'env').value({
-    VSCE_PAT: 'abc123'
+    VSCE_PAT: 'abc123',
   });
 
   const verifyAuth = proxyquire('../lib/verify-auth', {
-    execa: sinon.stub().withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd }).rejects()
+    execa: sinon
+      .stub()
+      .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+      .rejects(),
   });
 
-  await t.throwsAsync(() => verifyAuth(logger), { instanceOf: SemanticReleaseError, code: 'EINVALIDVSCETOKEN' });
+  await t.throwsAsync(() => verifyAuth(logger), {
+    instanceOf: SemanticReleaseError,
+    code: 'EINVALIDVSCETOKEN',
+  });
 });

--- a/test/verify-ovsx-auth.test.js
+++ b/test/verify-ovsx-auth.test.js
@@ -3,12 +3,12 @@ const sinon = require('sinon');
 const SemanticReleaseError = require('@semantic-release/error');
 
 const logger = {
-  log: sinon.fake()
+  log: sinon.fake(),
 };
 
-test('OVSX_PAT is set', async t => {
+test('OVSX_PAT is set', async (t) => {
   sinon.stub(process, 'env').value({
-    OVSX_PAT: 'abc123'
+    OVSX_PAT: 'abc123',
   });
 
   const verifyOvsxAuth = require('../lib/verify-ovsx-auth');
@@ -16,12 +16,15 @@ test('OVSX_PAT is set', async t => {
   await t.notThrowsAsync(() => verifyOvsxAuth(logger));
 });
 
-test('OVSX_PAT is invalid', async t => {
+test('OVSX_PAT is invalid', async (t) => {
   sinon.stub(process, 'env').value({
-    OVSX_PAT: ''
+    OVSX_PAT: '',
   });
 
   const verifyOvsxAuth = require('../lib/verify-ovsx-auth');
 
-  await t.throwsAsync(() => verifyOvsxAuth(logger), { instanceOf: SemanticReleaseError, code: 'EINVALIDOVSXPAT' });
+  await t.throwsAsync(() => verifyOvsxAuth(logger), {
+    instanceOf: SemanticReleaseError,
+    code: 'EINVALIDOVSXPAT',
+  });
 });

--- a/test/verify-ovsx-auth.test.js
+++ b/test/verify-ovsx-auth.test.js
@@ -2,11 +2,22 @@ const test = require('ava');
 const sinon = require('sinon');
 const SemanticReleaseError = require('@semantic-release/error');
 
-const logger = {
-  log: sinon.fake(),
-};
+test('OVSX_PAT is not set', async (t) => {
+  const logger = {
+    log: sinon.fake(),
+  };
+
+  const verifyOvsxAuth = require('../lib/verify-ovsx-auth');
+
+  await t.notThrowsAsync(() => verifyOvsxAuth(logger));
+  t.true(logger.log.calledTwice);
+});
 
 test('OVSX_PAT is set', async (t) => {
+  const logger = {
+    log: sinon.fake(),
+  };
+
   sinon.stub(process, 'env').value({
     OVSX_PAT: 'abc123',
   });
@@ -14,9 +25,14 @@ test('OVSX_PAT is set', async (t) => {
   const verifyOvsxAuth = require('../lib/verify-ovsx-auth');
 
   await t.notThrowsAsync(() => verifyOvsxAuth(logger));
+  t.true(logger.log.calledOnce);
 });
 
 test('OVSX_PAT is invalid', async (t) => {
+  const logger = {
+    log: sinon.fake(),
+  };
+
   sinon.stub(process, 'env').value({
     OVSX_PAT: '',
   });

--- a/test/verify-pkg.test.js
+++ b/test/verify-pkg.test.js
@@ -3,103 +3,115 @@ const test = require('ava');
 const proxyquire = require('proxyquire');
 const SemanticReleaseError = require('@semantic-release/error');
 
-test('package.json is found', async t => {
+test('package.json is found', async (t) => {
   const name = 'test';
   const publisher = 'tester';
 
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(true)
+      existsSync: sinon.stub().returns(true),
     },
     'fs-extra': {
       readJson: sinon.stub().returns({
         name,
-        publisher
-      })
-    }
+        publisher,
+      }),
+    },
   });
 
   await t.notThrowsAsync(() => verifyPkg());
 });
 
-test('package.json is not found', async t => {
+test('package.json is not found', async (t) => {
   const name = 'test';
   const publisher = 'tester';
 
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(false)
+      existsSync: sinon.stub().returns(false),
     },
     'fs-extra': {
       readJson: sinon.stub().returns({
         name,
-        publisher
-      })
-    }
+        publisher,
+      }),
+    },
   });
 
-  await t.throwsAsync(() => verifyPkg(), { instanceOf: SemanticReleaseError, code: 'ENOPKG' });
+  await t.throwsAsync(() => verifyPkg(), {
+    instanceOf: SemanticReleaseError,
+    code: 'ENOPKG',
+  });
 });
 
-test('package is valid', async t => {
+test('package is valid', async (t) => {
   const name = 'test';
   const publisher = 'tester';
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(true)
+      existsSync: sinon.stub().returns(true),
     },
     'fs-extra': {
       readJson: sinon.stub().returns({
         publisher,
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
   await t.notThrowsAsync(() => verifyPkg());
 });
 
-test('package is invalid', async t => {
+test('package is invalid', async (t) => {
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(true)
+      existsSync: sinon.stub().returns(true),
     },
     'fs-extra': {
-      readJson: sinon.stub().rejects()
-    }
+      readJson: sinon.stub().rejects(),
+    },
   });
 
-  await t.throwsAsync(() => verifyPkg(), { instanceOf: SemanticReleaseError, code: 'EINVALIDPKG' });
+  await t.throwsAsync(() => verifyPkg(), {
+    instanceOf: SemanticReleaseError,
+    code: 'EINVALIDPKG',
+  });
 });
 
-test('package is missing name', async t => {
+test('package is missing name', async (t) => {
   const publisher = 'tester';
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(true)
+      existsSync: sinon.stub().returns(true),
     },
     'fs-extra': {
       readJson: sinon.stub().returns({
-        publisher
-      })
-    }
+        publisher,
+      }),
+    },
   });
 
-  await t.throwsAsync(() => verifyPkg(), { instanceOf: SemanticReleaseError, code: 'ENOPKGNAME' });
+  await t.throwsAsync(() => verifyPkg(), {
+    instanceOf: SemanticReleaseError,
+    code: 'ENOPKGNAME',
+  });
 });
 
-test('package is missing publisher', async t => {
+test('package is missing publisher', async (t) => {
   const name = 'test';
   const verifyPkg = proxyquire('../lib/verify-pkg', {
     fs: {
-      existsSync: sinon.stub().returns(true)
+      existsSync: sinon.stub().returns(true),
     },
     'fs-extra': {
       readJson: sinon.stub().returns({
-        name
-      })
-    }
+        name,
+      }),
+    },
   });
 
-  await t.throwsAsync(() => verifyPkg(), { instanceOf: SemanticReleaseError, code: 'ENOPUBLISHER' });
+  await t.throwsAsync(() => verifyPkg(), {
+    instanceOf: SemanticReleaseError,
+    code: 'ENOPUBLISHER',
+  });
 });

--- a/test/verify-target.test.js
+++ b/test/verify-target.test.js
@@ -1,0 +1,55 @@
+const sinon = require('sinon');
+const test = require('ava');
+const proxyquire = require('proxyquire');
+const SemanticReleaseError = require('@semantic-release/error');
+
+test('VSCE_TARGET is not set', async (t) => {
+  const vscePackage = sinon.stub().returns({
+    Targets: new Map(),
+  });
+  const verifyTarget = proxyquire('../lib/verify-target', {
+    'vsce/out/package': vscePackage,
+  });
+
+  await t.notThrowsAsync(() => verifyTarget());
+});
+
+test('VSCE_TARGET is valid', async (t) => {
+  sinon.stub(process, 'env').value({
+    VSCE_TARGET: 'linux-x64',
+  });
+
+  const verifyTarget = require('../lib/verify-target');
+
+  await t.notThrowsAsync(() => verifyTarget());
+});
+
+test('VSCE_TARGET is empty', async (t) => {
+  const vscePackage = sinon.stub().returns({
+    Targets: new Map(),
+  });
+  const verifyTarget = proxyquire('../lib/verify-target', {
+    'vsce/out/package': vscePackage,
+  });
+  sinon.stub(process, 'env').value({
+    VSCE_TARGET: '',
+  });
+
+  await t.throwsAsync(() => verifyTarget(), {
+    instanceOf: SemanticReleaseError,
+    code: 'EINVALIDVSCETARGET',
+  });
+  t.false(vscePackage.called);
+});
+
+test('VSCE_TARGET is unsupported', async (t) => {
+  sinon.stub(process, 'env').value({
+    VSCE_TARGET: 'whatever-x64',
+  });
+  const verifyTarget = require('../lib/verify-target');
+
+  await t.throwsAsync(() => verifyTarget(), {
+    instanceOf: SemanticReleaseError,
+    code: 'EUNSUPPORTEDVSCETARGET',
+  });
+});

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -3,47 +3,47 @@ const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 
 const logger = {
-  log: sinon.fake()
+  log: sinon.fake(),
 };
 const cwd = process.cwd();
 
-test('resolves', async t => {
+test('resolves', async (t) => {
   const verify = proxyquire('../lib/verify', {
     './verify-auth': sinon.stub().resolves(),
-    './verify-pkg': sinon.stub().resolves()
+    './verify-pkg': sinon.stub().resolves(),
   });
 
   await t.notThrowsAsync(() => verify({}, { logger, cwd }));
 });
 
-test('rejects with verify-auth', async t => {
+test('rejects with verify-auth', async (t) => {
   const verify = proxyquire('../lib/verify', {
     './verify-auth': sinon.stub().rejects(),
-    './verify-pkg': sinon.stub().resolves()
+    './verify-pkg': sinon.stub().resolves(),
   });
 
   await t.throwsAsync(() => verify({}, { logger, cwd }));
 });
 
-test('rejects with verify-pkg', async t => {
+test('rejects with verify-pkg', async (t) => {
   const verify = proxyquire('../lib/verify', {
     './verify-auth': sinon.stub().resolves(),
-    './verify-pkg': sinon.stub().rejects()
+    './verify-pkg': sinon.stub().rejects(),
   });
 
   await t.throwsAsync(() => verify({}, { logger, cwd }));
 });
 
-test('is does not verify the auth tokens if publishing is disabled', async t => {
+test('is does not verify the auth tokens if publishing is disabled', async (t) => {
   const stubs = {
     verifyPkgStub: sinon.stub().resolves(),
     verifyAuthStub: sinon.stub().resolves(),
-    verifyOvsxAuthStub: sinon.stub().resolves()
+    verifyOvsxAuthStub: sinon.stub().resolves(),
   };
   const verify = proxyquire('../lib/verify', {
     './verify-pkg': stubs.verifyPkgStub,
     './verify-auth': stubs.verifyAuthStub,
-    './verify-ovsx-auth': stubs.verifyOvsxAuthStub
+    './verify-ovsx-auth': stubs.verifyOvsxAuthStub,
   });
 
   await verify({ publish: false }, { logger, cwd });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -9,26 +9,54 @@ const cwd = process.cwd();
 
 test('resolves', async (t) => {
   const verify = proxyquire('../lib/verify', {
-    './verify-auth': sinon.stub().resolves(),
     './verify-pkg': sinon.stub().resolves(),
+    './verify-target': sinon.stub().resolves(),
+    './verify-auth': sinon.stub().resolves(),
+    './verify-ovsx-auth': sinon.stub().resolves(),
   });
 
   await t.notThrowsAsync(() => verify({}, { logger, cwd }));
 });
 
-test('rejects with verify-auth', async (t) => {
+test('rejects with verify-pkg', async (t) => {
   const verify = proxyquire('../lib/verify', {
-    './verify-auth': sinon.stub().rejects(),
-    './verify-pkg': sinon.stub().resolves(),
+    './verify-pkg': sinon.stub().rejects(),
+    './verify-target': sinon.stub().resolves(),
+    './verify-auth': sinon.stub().resolves(),
+    './verify-ovsx-auth': sinon.stub().resolves(),
   });
 
   await t.throwsAsync(() => verify({}, { logger, cwd }));
 });
 
-test('rejects with verify-pkg', async (t) => {
+test('rejects with verify-target', async (t) => {
   const verify = proxyquire('../lib/verify', {
+    './verify-pkg': sinon.stub().resolves(),
+    './verify-target': sinon.stub().rejects(),
     './verify-auth': sinon.stub().resolves(),
-    './verify-pkg': sinon.stub().rejects(),
+    './verify-ovsx-auth': sinon.stub().resolves(),
+  });
+
+  await t.throwsAsync(() => verify({}, { logger, cwd }));
+});
+
+test('rejects with verify-auth', async (t) => {
+  const verify = proxyquire('../lib/verify', {
+    './verify-pkg': sinon.stub().resolves(),
+    './verify-target': sinon.stub().resolves(),
+    './verify-auth': sinon.stub().rejects(),
+    './verify-ovsx-auth': sinon.stub().resolves(),
+  });
+
+  await t.throwsAsync(() => verify({}, { logger, cwd }));
+});
+
+test('rejects with verify-ovsx-auth', async (t) => {
+  const verify = proxyquire('../lib/verify', {
+    './verify-pkg': sinon.stub().resolves(),
+    './verify-target': sinon.stub().resolves(),
+    './verify-auth': sinon.stub().resolves(),
+    './verify-ovsx-auth': sinon.stub().rejects(),
   });
 
   await t.throwsAsync(() => verify({}, { logger, cwd }));
@@ -37,11 +65,13 @@ test('rejects with verify-pkg', async (t) => {
 test('is does not verify the auth tokens if publishing is disabled', async (t) => {
   const stubs = {
     verifyPkgStub: sinon.stub().resolves(),
+    verifyTargetStub: sinon.stub().resolves(),
     verifyAuthStub: sinon.stub().resolves(),
     verifyOvsxAuthStub: sinon.stub().resolves(),
   };
   const verify = proxyquire('../lib/verify', {
     './verify-pkg': stubs.verifyPkgStub,
+    './verify-target': stubs.verifyTargetStub,
     './verify-auth': stubs.verifyAuthStub,
     './verify-ovsx-auth': stubs.verifyOvsxAuthStub,
   });


### PR DESCRIPTION
## New features

- The existing `packageVsix` option can now be explicitly disabled with `false`
- A new `publishPackagePath` option was added, which allows the use of globs like `*.vsix`
- A new environment variable is supported: `VSCE_TARGET`

Check the documentation for [an example](https://github.com/felipecrs/semantic-release-vsce/blob/multi-arch/README.md#platform-specific-on-github-actions) on how these new features can be combined to achieve platform-specific extensions publishing.