### PR TITLE
feat: allow to disable publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 | Option        | Type                  | Description                                                                                                                        |
 | ------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `packageVsix` | `boolean` or `string` | If set to `true`, the plugin will generate a `.vsix` file. If is a string, it will be used as value for `--out` of `vsce package`. |
+| `publish`     | `boolean`             | The plugin will publish the package unless this option is set to `false`, in which case il will only package the extension.        |
 
 ### Environment Variables
 
-| Variable   | Description                                                                             |
-| ---------- | --------------------------------------------------------------------------------------- |
-| `VSCE_PAT` | **Required**. The personal access token to publish the extension of VS Code Marketplace |
-| `OVSX_PAT` | _Optional_. The personal access token to push to OpenVSX                                |
+| Variable   | Description                                                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `VSCE_PAT` | _**Required**_ unless `publish` is set to `false`. The personal access token to publish the extension of VS Code Marketplace |
+| `OVSX_PAT` | _Optional_. The personal access token to push to OpenVSX                                                                     |
 
 ### Publishing to OpenVSX
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 | Option        | Type                  | Description                                                                                                                        |
 | ------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | `packageVsix` | `boolean` or `string` | If set to `true`, the plugin will generate a `.vsix` file. If is a string, it will be used as value for `--out` of `vsce package`. |
-| `publish`     | `boolean`             | The plugin will publish the package unless this option is set to `false`, in which case il will only package the extension.        |
+| `publish`     | `boolean`             | The plugin will publish the package unless this option is set to `false`, in which case it will only package the extension `vsix`.        |
 
 ### Environment Variables
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ let prepared = false;
 let packagePath;
 
 async function verifyConditions (pluginConfig, { logger }) {
-  await verifyVsce(logger);
+  await verifyVsce(logger, pluginConfig);
   verified = true;
 }
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,12 @@ async function publish (pluginConfig, { nextRelease: { version }, logger }) {
     // BC: prior to semantic-release v15 prepare was part of publish
     packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger);
   }
+
+  // If publishing is disabled, return early.
+  if (pluginConfig?.publish === false) {
+    return;
+  }
+
   return vscePublish(version, packagePath, logger);
 }
 

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,10 +2,11 @@ const verifyPkg = require('./verify-pkg');
 const verifyAuth = require('./verify-auth');
 const verifyOvsxAuth = require('./verify-ovsx-auth');
 
-module.exports = async logger => {
+module.exports = async (logger, pluginConfig) => {
   await verifyPkg();
 
-  await verifyAuth(logger);
-
-  await verifyOvsxAuth(logger);
+  if (pluginConfig?.publish !== false) {
+    await verifyAuth(logger);
+    await verifyOvsxAuth(logger);
+  }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -139,3 +139,18 @@ test('publish that is already verified & prepared', async t => {
     semanticReleasePayload.logger
   ]);
 });
+
+test('it does not publish the package if publishing is disabled', async t => {
+  const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
+  const { prepare, publish, verifyConditions } = proxyquire('../index.js', {
+    './lib/verify': verifyVsceStub,
+    './lib/publish': vscePublishStub,
+    './lib/prepare': vscePrepareStub
+  });
+
+  await verifyConditions({ ...pluginConfig, publish: false }, semanticReleasePayload);
+  await prepare({ ...pluginConfig, publish: false }, semanticReleasePayload);
+  await publish({ ...pluginConfig, publish: false }, semanticReleasePayload);
+
+  t.true(vscePublishStub.notCalled);
+});

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -32,3 +32,21 @@ test('rejects with verify-pkg', async t => {
 
   await t.throwsAsync(() => verify(logger));
 });
+
+test('is does not verify the auth tokens if publishing is disabled', async t => {
+  const stubs = {
+    verifyPkgStub: sinon.stub().resolves(),
+    verifyAuthStub: sinon.stub().resolves(),
+    verifyOvsxAuthStub: sinon.stub().resolves()
+  };
+  const verify = proxyquire('../lib/verify', {
+    './verify-pkg': stubs.verifyPkgStub,
+    './verify-auth': stubs.verifyAuthStub,
+    './verify-ovsx-auth': stubs.verifyOvsxAuthStub
+  });
+
+  await verify(logger, { publish: false });
+
+  t.true(stubs.verifyAuthStub.notCalled);
+  t.true(stubs.verifyOvsxAuthStub.notCalled);
+});


### PR DESCRIPTION
This PR introduces a new optional `publish` option that allows skipping publishing the extension.

- If the `publish` option is set to `false` the extension will not be published.
- If the `publish` option is set to `true` or is `undefined` the extension will be published, which means that _backward compatibility is preserved_.

The PR also adds relevant tests and updates the README accordingly.

Closes #312 