### PR TITLE
feat: log OpenVSX URL after publishing

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -29,9 +29,11 @@ module.exports = async (version, packagePath, logger) => {
     logger.log('Now publishing to OpenVSX');
 
     await execa('ovsx', ['publish', packagePath], { stdio: 'inherit' });
+    const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
+
+    logger.log(`The new ovsx version is available at ${ovsxUrl}`);
 
     // TODO: uncomment after https://github.com/semantic-release/semantic-release/issues/2123
-    // const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
     // const ovsxRelease = {
     //   name: 'Open VSX Registry',
     //   url: ovsxUrl


### PR DESCRIPTION
Even though two releases can't be returned, the URL of the new ovsx version could still be printed