### PR TITLE
Add option for `vsce` arguments & respect `cwd` context

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,29 +6,29 @@ let verified = false;
 let prepared = false;
 let packagePath;
 
-async function verifyConditions (pluginConfig, { logger }) {
-  await verifyVsce(logger, pluginConfig);
+async function verifyConditions (pluginConfig, context) {
+  await verifyVsce(context, pluginConfig);
   verified = true;
 }
 
-async function prepare (pluginConfig, { nextRelease: { version }, logger }) {
+async function prepare (pluginConfig, context) {
   if (!verified) {
-    await verifyVsce(logger);
+    await verifyVsce(context);
     verified = true;
   }
-  packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger);
+  packagePath = await vscePrepare(context, pluginConfig);
   prepared = true;
 }
 
-async function publish (pluginConfig, { nextRelease: { version }, logger }) {
+async function publish (pluginConfig, context) {
   if (!verified) {
-    await verifyVsce(logger);
+    await verifyVsce(context);
     verified = true;
   }
 
   if (!prepared) {
     // BC: prior to semantic-release v15 prepare was part of publish
-    packagePath = await vscePrepare(version, pluginConfig.packageVsix, logger);
+    packagePath = await vscePrepare(context, pluginConfig);
   }
 
   // If publishing is disabled, return early.
@@ -36,7 +36,7 @@ async function publish (pluginConfig, { nextRelease: { version }, logger }) {
     return;
   }
 
-  return vscePublish(version, packagePath, logger);
+  return vscePublish(context, packagePath);
 }
 
 module.exports = {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 const { isOvsxEnabled } = require('./verify-ovsx-auth');
 
-module.exports = async (version, packageVsix, logger) => {
+module.exports = async ({ nextRelease: { version }, logger, cwd }, { packageVsix }) => {
   const ovsxEnabled = isOvsxEnabled();
   if (packageVsix || ovsxEnabled) {
     if (!packageVsix && ovsxEnabled) {
@@ -22,7 +22,7 @@ module.exports = async (version, packageVsix, logger) => {
 
     const options = ['package', version, '--no-git-tag-version', '--out', packagePath];
 
-    await execa('vsce', options, { stdio: 'inherit' });
+    await execa('vsce', options, { stdio: 'inherit', cwd });
 
     return packagePath;
   }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,7 +2,7 @@ const execa = require('execa');
 const { readJson } = require('fs-extra');
 const { isOvsxEnabled } = require('./verify-ovsx-auth');
 
-module.exports = async (version, packagePath, logger) => {
+module.exports = async ({ nextRelease: { version }, logger, cwd }, packagePath) => {
   const { publisher, name } = await readJson('./package.json');
 
   const options = ['publish'];
@@ -15,7 +15,7 @@ module.exports = async (version, packagePath, logger) => {
     options.push(...[version, '--no-git-tag-version']);
   }
 
-  await execa('vsce', options, { stdio: 'inherit' });
+  await execa('vsce', options, { stdio: 'inherit', cwd });
 
   const vsceUrl = `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`;
   logger.log(`The new version is available at ${vsceUrl}.`);
@@ -28,7 +28,7 @@ module.exports = async (version, packagePath, logger) => {
   if (isOvsxEnabled()) {
     logger.log('Now publishing to OpenVSX');
 
-    await execa('ovsx', ['publish', packagePath], { stdio: 'inherit' });
+    await execa('ovsx', ['publish', packagePath], { stdio: 'inherit', cwd });
     const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
 
     logger.log(`The new ovsx version is available at ${ovsxUrl}`);

--- a/lib/verify-auth.js
+++ b/lib/verify-auth.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 const SemanticReleaseError = require('@semantic-release/error');
 
-module.exports = async (logger) => {
+module.exports = async ({ logger, cwd }) => {
   logger.log('Verifying authentication for vsce');
 
   if (!process.env.VSCE_PAT) {
@@ -9,7 +9,7 @@ module.exports = async (logger) => {
   }
 
   try {
-    await execa('vsce', ['verify-pat']);
+    await execa('vsce', ['verify-pat'], { cwd });
   } catch (e) {
     throw new SemanticReleaseError(`Invalid vsce token. Additional information:\n\n${e}`, 'EINVALIDVSCETOKEN');
   }

--- a/lib/verify-ovsx-auth.js
+++ b/lib/verify-ovsx-auth.js
@@ -4,7 +4,7 @@ const isOvsxEnabled = () => {
   return 'OVSX_PAT' in process.env;
 };
 
-module.exports = async (logger) => {
+module.exports = async ({ logger, cwd }) => {
   logger.log('Verifying authentication for ovsx');
 
   if (!isOvsxEnabled()) {
@@ -18,7 +18,7 @@ module.exports = async (logger) => {
 
   // TODO: waiting for https://github.com/eclipse/openvsx/issues/313
   // try {
-  //   await execa('ovsx', ['verify-pat']);
+  //   await execa('ovsx', ['verify-pat'], { cwd });
   // } catch (e) {
   //   throw new SemanticReleaseError(`Invalid ovsx personal access token. Additional information:\n\n${e}`, 'EINVALIDOVSXPAT');
   // }

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -2,11 +2,11 @@ const verifyPkg = require('./verify-pkg');
 const verifyAuth = require('./verify-auth');
 const verifyOvsxAuth = require('./verify-ovsx-auth');
 
-module.exports = async (logger, pluginConfig) => {
+module.exports = async (context, pluginConfig) => {
   await verifyPkg();
 
   if (pluginConfig?.publish !== false) {
-    await verifyAuth(logger);
-    await verifyOvsxAuth(logger);
+    await verifyAuth(context);
+    await verifyOvsxAuth(context);
   }
 };


### PR DESCRIPTION
Sorry that this is 2 features in one pull request.

I was trying to make this plugin compatible with [dhoulb/multi-semantic-release](https://github.com/dhoulb/multi-semantic-release) in a monorepo workfow. This presented 2 challenges:

1. `vsce` does **NOT** respect the `.vscodeignore` file when dealing with node references to files outside the root directory (such as `node_modules` for the monorepo root)
2. `execa`, which is used to execute `vsce` uses `process.cwd()` as it's working directory, as opposed to the `semanttic-release` context's `cwd`

For issue `1.`,  I resorted to adding the argument `--no-dependencies` which I needed to pass to `vsce` ([3d5f39666)](https://github.com/felipecrs/semantic-release-vsce/commit/3d5f39666e8870c9298c06c5e33661bdb84ee47f)).

For issue `2.` I used the context passed along to the plugin by `semantic-release` and used the included `cwd` parameter for the `execa` calls ([910e4ad](https://github.com/felipecrs/semantic-release-vsce/commit/910e4ada3d4e60e884f539e2db6c77df01e1a46e)).

I already added the relevant documentation for the `args` option ([db9da20](https://github.com/felipecrs/semantic-release-vsce/commit/db9da20e4113b35c247521a1dad72ba97df3fd1b)). The `cwd` should not require any documentation as it does not change the behavior of the plugin.