### PR TITLE
feat: add support for a different packageRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Which `.vsix` file (or files) to publish. This controls what value will be used 
 | `false`            | do not use a `.vsix` file to publish, which causes `vsce` to package the extension as part of the publish process |
 | a `string`         | publish the specified `.vsix` file(s). This can be a glob pattern, or a comma-separated list of files             |
 
+### `packageRoot`
+
+The directory of the extension relative to the current working directory. Defaults to `cwd`.
+
 ### Environment variables
 
 The following environment variables are supported by this plugin:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // @ts-check
 
+const path = require('path');
 const verifyVsce = require('./lib/verify');
 const vscePublish = require('./lib/publish');
 const vscePrepare = require('./lib/prepare');
@@ -9,6 +10,7 @@ let prepared = false;
 let packagePath;
 
 async function verifyConditions(pluginConfig, { logger, cwd }) {
+  cwd = getPackageRoot(pluginConfig, cwd);
   await verifyVsce(pluginConfig, { logger, cwd });
   verified = true;
 }
@@ -17,6 +19,7 @@ async function prepare(
   pluginConfig,
   { nextRelease: { version }, logger, cwd },
 ) {
+  cwd = getPackageRoot(pluginConfig, cwd);
   if (!verified) {
     await verifyVsce(pluginConfig, { logger, cwd });
     verified = true;
@@ -34,6 +37,7 @@ async function publish(
   pluginConfig,
   { nextRelease: { version }, logger, cwd },
 ) {
+  cwd = getPackageRoot(pluginConfig, cwd);
   if (!verified) {
     await verifyVsce(pluginConfig, { logger, cwd });
     verified = true;
@@ -61,6 +65,12 @@ async function publish(
   }
 
   return vscePublish(version, packagePath, logger, cwd);
+}
+
+function getPackageRoot(pluginConfig, cwd) {
+  return pluginConfig.packageRoot
+    ? path.join(cwd, pluginConfig.packageRoot)
+    : cwd;
 }
 
 module.exports = {

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,6 +2,7 @@
 
 const execa = require('execa');
 const { readJson } = require('fs-extra');
+const path = require('path');
 const { isOvsxPublishEnabled, isTargetEnabled } = require('./utils');
 
 module.exports = async (version, packageVsix, logger, cwd) => {
@@ -23,7 +24,7 @@ module.exports = async (version, packageVsix, logger, cwd) => {
     if (typeof packageVsix === 'string') {
       packagePath = packageVsix;
     } else {
-      const { name } = await readJson('./package.json');
+      const { name } = await readJson(path.join(cwd, './package.json'));
       if (isTargetEnabled()) {
         packagePath = `${name}-${process.env.VSCE_TARGET}-${version}.vsix`;
       } else {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -2,6 +2,7 @@
 
 const execa = require('execa');
 const { readJson } = require('fs-extra');
+const path = require('path');
 const {
   isOvsxPublishEnabled,
   isTargetEnabled,
@@ -9,7 +10,7 @@ const {
 } = require('./utils');
 
 module.exports = async (version, packagePath, logger, cwd) => {
-  const { publisher, name } = await readJson('./package.json');
+  const { publisher, name } = await readJson(path.join(cwd, './package.json'));
 
   const options = ['publish'];
 

--- a/lib/verify-pkg.js
+++ b/lib/verify-pkg.js
@@ -3,11 +3,14 @@
 const SemanticReleaseError = require('@semantic-release/error');
 const { readJson } = require('fs-extra');
 const fs = require('fs');
+const path = require('path');
 
-module.exports = async () => {
-  if (!fs.existsSync('./package.json')) {
+module.exports = async (cwd) => {
+  const packagePath = path.join(cwd, './package.json');
+
+  if (!fs.existsSync(packagePath)) {
     throw new SemanticReleaseError(
-      'The `package.json` was not found. A `package.json` is required to release with vsce.',
+      `${packagePath} was not found. A \`package.json\` is required to release with vsce.`,
       'ENOPKG',
     );
   }
@@ -15,7 +18,7 @@ module.exports = async () => {
   let packageJson;
 
   try {
-    packageJson = await readJson('./package.json');
+    packageJson = await readJson(packagePath);
   } catch {
     throw new SemanticReleaseError(
       'The `package.json` seems to be invalid.',

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -8,7 +8,7 @@ const verifyTarget = require('./verify-target');
 const { isOvsxPublishEnabled, isVscePublishEnabled } = require('./utils');
 
 module.exports = async (pluginConfig, { logger, cwd }) => {
-  await verifyPkg();
+  await verifyPkg(cwd);
   await verifyTarget();
 
   if (pluginConfig?.publish !== false) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,3 +229,33 @@ test('expand globs if publishPackagePath is set', async (t) => {
     semanticReleasePayload.cwd,
   ]);
 });
+
+test('publishes an extension in a non-root folder', async (t) => {
+  const { verifyVsceStub, vscePrepareStub, vscePublishStub } = t.context.stubs;
+  const { publish } = proxyquire('../index.js', {
+    './lib/verify': verifyVsceStub,
+    './lib/publish': vscePublishStub,
+    './lib/prepare': vscePrepareStub,
+    glob: {
+      glob: {
+        sync: sinon.stub().returns(['package1.vsix', 'package2.vsix']),
+      },
+    },
+  });
+
+  const pluginConfig = {
+    packageRoot: './vscode-extension',
+  };
+  const resolvedCwd = `${semanticReleasePayload.cwd}/vscode-extension`;
+
+  await publish(pluginConfig, semanticReleasePayload);
+
+  t.true(verifyVsceStub.calledOnce);
+  t.true(vscePrepareStub.calledOnce);
+  t.deepEqual(vscePublishStub.getCall(0).args, [
+    semanticReleasePayload.nextRelease.version,
+    undefined,
+    semanticReleasePayload.logger,
+    resolvedCwd,
+  ]);
+});

--- a/test/verify-pkg.test.js
+++ b/test/verify-pkg.test.js
@@ -3,6 +3,8 @@ const test = require('ava');
 const proxyquire = require('proxyquire');
 const SemanticReleaseError = require('@semantic-release/error');
 
+const cwd = process.cwd();
+
 test('package.json is found', async (t) => {
   const name = 'test';
   const publisher = 'tester';
@@ -19,7 +21,7 @@ test('package.json is found', async (t) => {
     },
   });
 
-  await t.notThrowsAsync(() => verifyPkg());
+  await t.notThrowsAsync(() => verifyPkg(cwd));
 });
 
 test('package.json is not found', async (t) => {
@@ -38,7 +40,7 @@ test('package.json is not found', async (t) => {
     },
   });
 
-  await t.throwsAsync(() => verifyPkg(), {
+  await t.throwsAsync(() => verifyPkg(cwd), {
     instanceOf: SemanticReleaseError,
     code: 'ENOPKG',
   });
@@ -59,7 +61,7 @@ test('package is valid', async (t) => {
     },
   });
 
-  await t.notThrowsAsync(() => verifyPkg());
+  await t.notThrowsAsync(() => verifyPkg(cwd));
 });
 
 test('package is invalid', async (t) => {
@@ -72,7 +74,7 @@ test('package is invalid', async (t) => {
     },
   });
 
-  await t.throwsAsync(() => verifyPkg(), {
+  await t.throwsAsync(() => verifyPkg(cwd), {
     instanceOf: SemanticReleaseError,
     code: 'EINVALIDPKG',
   });
@@ -91,7 +93,7 @@ test('package is missing name', async (t) => {
     },
   });
 
-  await t.throwsAsync(() => verifyPkg(), {
+  await t.throwsAsync(() => verifyPkg(cwd), {
     instanceOf: SemanticReleaseError,
     code: 'ENOPKGNAME',
   });
@@ -110,7 +112,7 @@ test('package is missing publisher', async (t) => {
     },
   });
 
-  await t.throwsAsync(() => verifyPkg(), {
+  await t.throwsAsync(() => verifyPkg(cwd), {
     instanceOf: SemanticReleaseError,
     code: 'ENOPUBLISHER',
   });


### PR DESCRIPTION
👋 Hello

Thanks for putting this together 🥳 It's worked swimmingly for me so far. I refactored my repo recently so the VS Code extension is no longer on the root-level of the repo, without checking whether all the tools would support that. Turns out this one didn't.

This PR adapts the internals so the extension can be in a non-root folder. Both of these scenarios should be covered. In my case it was the 2nd scenario that caused problems.

- `cwd` is root but extension is not
- `cwd` is _not_ root, extension is in `cwd`

Tested OK in https://github.com/wkillerud/some-sass using `patch-package`

Fixes #32