### PR TITLE
docs: remove win32-ia32 platform from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,6 @@ jobs:
             target: win32-x64
             npm_config_arch: x64
           - os: windows-latest
-            target: win32-ia32
-            npm_config_arch: ia32
-          - os: windows-latest
             target: win32-arm64
             npm_config_arch: arm
           - os: ubuntu-latest


### PR DESCRIPTION
As it's not longer supported by vscode.

Refs: https://github.com/microsoft/vscode-platform-specific-sample/pull/10
Refs: https://github.com/microsoft/vscode-platform-specific-sample/pull/11
