### PR TITLE
ci: publish with npm provenance statement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
 
     needs: test
 
+    permissions:
+      id-token: write # for npm provenance
+
     steps:
       - uses: actions/checkout@v4
       - uses: volta-cli/action@v4

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
It'd be great if this package published with [npm provenance statements](https://docs.npmjs.com/generating-provenance-statements). Since publishing is already automated and uses GitHub Actions, I believe these are the only changes needed.