### PR TITLE
fix: `ovsx` and `vsce` commands not found when using `pnpm`

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -44,7 +44,12 @@ export async function prepare(version, packageVsix, logger, cwd) {
       options.push('--target', process.env.VSCE_TARGET);
     }
 
-    await execa('vsce', options, { stdio: 'inherit', preferLocal: true, cwd });
+    await execa('vsce', options, {
+      stdio: 'inherit',
+      preferLocal: true,
+      localDir: import.meta.dirname,
+      cwd,
+    });
 
     return packagePath;
   }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -43,7 +43,12 @@ export async function publish(version, packagePath, logger, cwd) {
   if (isVscePublishEnabled()) {
     logger.log(message + ' to Visual Studio Marketplace');
 
-    await execa('vsce', options, { stdio: 'inherit', preferLocal: true, cwd });
+    await execa('vsce', options, {
+      stdio: 'inherit',
+      preferLocal: true,
+      localDir: import.meta.dirname,
+      cwd,
+    });
     const vsceUrl = `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`;
 
     logger.log(`The new version is available at ${vsceUrl}.`);
@@ -57,7 +62,12 @@ export async function publish(version, packagePath, logger, cwd) {
     logger.log(message + 'to Open VSX Registry');
 
     // When publishing to OpenVSX, packagePath will be always set
-    await execa('ovsx', options, { stdio: 'inherit', preferLocal: true, cwd });
+    await execa('ovsx', options, {
+      stdio: 'inherit',
+      preferLocal: true,
+      localDir: import.meta.dirname,
+      cwd,
+    });
     const ovsxUrl = `https://open-vsx.org/extension/${publisher}/${name}/${version}`;
 
     logger.log(`The new ovsx version is available at ${ovsxUrl}`);

--- a/lib/verify-ovsx-auth.js
+++ b/lib/verify-ovsx-auth.js
@@ -15,7 +15,11 @@ export async function verifyOvsxAuth(logger, cwd) {
   }
 
   try {
-    await execa('ovsx', ['verify-pat'], { preferLocal: true, cwd });
+    await execa('ovsx', ['verify-pat'], {
+      preferLocal: true,
+      localDir: import.meta.dirname,
+      cwd,
+    });
   } catch (error) {
     throw new SemanticReleaseError(
       `Invalid ovsx personal access token. Additional information:\n\n${error}`,

--- a/lib/verify-vsce-auth.js
+++ b/lib/verify-vsce-auth.js
@@ -29,7 +29,11 @@ export async function verifyVsceAuth(logger, cwd) {
   }
 
   try {
-    await execa('vsce', vsceArguments, { preferLocal: true, cwd });
+    await execa('vsce', vsceArguments, {
+      preferLocal: true,
+      localDir: import.meta.dirname,
+      cwd,
+    });
   } catch (error) {
     throw new SemanticReleaseError(
       `Invalid vsce personal access token or azure credential. Additional information:\n\n${error}`,

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -1,6 +1,7 @@
 import avaTest from 'ava';
 import { fake, stub } from 'sinon';
 import esmock from 'esmock';
+import path from 'node:path';
 import process from 'node:process';
 
 // Run tests serially to avoid env pollution
@@ -9,6 +10,8 @@ const test = avaTest.serial;
 const logger = {
   log: fake(),
 };
+// eslint-disable-next-line unicorn/prevent-abbreviations
+const localDir = path.resolve(import.meta.dirname, '../lib');
 const cwd = process.cwd();
 
 test.beforeEach((t) => {
@@ -66,7 +69,12 @@ test('packageVsix is a string', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['package', version, '--no-git-tag-version', '--out', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    {
+      stdio: 'inherit',
+      preferLocal: true,
+      localDir,
+      cwd,
+    },
   ]);
 });
 
@@ -95,7 +103,7 @@ test('packageVsix is true', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['package', version, '--no-git-tag-version', '--out', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -128,7 +136,7 @@ test('packageVsix is not set but OVSX_PAT is', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['package', version, '--no-git-tag-version', '--out', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -171,7 +179,7 @@ test('packageVsix when target is set', async (t) => {
       '--target',
       target,
     ],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -203,6 +211,6 @@ test('packageVsix when target is set to universal', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['package', version, '--no-git-tag-version', '--out', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -1,6 +1,7 @@
 import avaTest from 'ava';
 import { fake, stub } from 'sinon';
 import esmock from 'esmock';
+import path from 'node:path';
 
 // Run tests serially to avoid env pollution
 const test = avaTest.serial;
@@ -8,6 +9,8 @@ const test = avaTest.serial;
 const logger = {
   log: fake(),
 };
+// eslint-disable-next-line unicorn/prevent-abbreviations
+const localDir = path.resolve(import.meta.dirname, '../lib');
 const cwd = process.cwd();
 
 test.beforeEach((t) => {
@@ -50,7 +53,7 @@ test('publish to vs marketplace with VSCE_PAT', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['publish', version, '--no-git-tag-version'],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -85,7 +88,7 @@ test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=true', async (t) => {
   t.deepEqual(arguments0, [
     'vsce',
     ['publish', '--packagePath', packagePath, '--azure-credential'],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -120,7 +123,7 @@ test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=1', async (t) => {
   t.deepEqual(arguments0, [
     'vsce',
     ['publish', '--packagePath', packagePath, '--azure-credential'],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -155,7 +158,7 @@ test('publish with packagePath', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -190,7 +193,7 @@ test('publish with multiple packagePath', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['publish', '--packagePath', ...packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -226,7 +229,7 @@ test('publish with target', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['publish', version, '--no-git-tag-version', '--target', target],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -262,7 +265,7 @@ test('publish to OpenVSX', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'vsce',
     ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 
   // t.deepEqual(result[1], {
@@ -272,7 +275,7 @@ test('publish to OpenVSX', async (t) => {
   t.deepEqual(execaStub.getCall(1).args, [
     'ovsx',
     ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 
@@ -308,7 +311,7 @@ test('publish to OpenVSX only', async (t) => {
   t.deepEqual(execaStub.getCall(0).args, [
     'ovsx',
     ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, cwd },
+    { stdio: 'inherit', preferLocal: true, localDir, cwd },
   ]);
 });
 

--- a/test/verify-ovsx-auth.test.js
+++ b/test/verify-ovsx-auth.test.js
@@ -2,10 +2,13 @@ import avaTest from 'ava';
 import { fake, stub } from 'sinon';
 import esmock from 'esmock';
 import SemanticReleaseError from '@semantic-release/error';
+import path from 'node:path';
 
 // Run tests serially to avoid env pollution
 const test = avaTest.serial;
 
+// eslint-disable-next-line unicorn/prevent-abbreviations
+const localDir = path.resolve(import.meta.dirname, '../lib');
 const cwd = process.cwd();
 
 test('OVSX_PAT is set', async (t) => {
@@ -20,7 +23,7 @@ test('OVSX_PAT is set', async (t) => {
   const { verifyOvsxAuth } = await esmock('../lib/verify-ovsx-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('ovsx', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('ovsx', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .resolves(),
     },
   });

--- a/test/verify-vsce-auth.test.js
+++ b/test/verify-vsce-auth.test.js
@@ -2,6 +2,7 @@ import avaTest from 'ava';
 import { fake, stub } from 'sinon';
 import esmock from 'esmock';
 import SemanticReleaseError from '@semantic-release/error';
+import path from 'node:path';
 
 // Run tests serially to avoid env pollution
 const test = avaTest.serial;
@@ -9,6 +10,8 @@ const test = avaTest.serial;
 const logger = {
   log: fake(),
 };
+// eslint-disable-next-line unicorn/prevent-abbreviations
+const localDir = path.resolve(import.meta.dirname, '../lib');
 const cwd = process.cwd();
 
 test('VSCE_PAT is set', async (t) => {
@@ -19,7 +22,7 @@ test('VSCE_PAT is set', async (t) => {
   const { verifyVsceAuth } = await esmock('../lib/verify-vsce-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('vsce', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .resolves(),
     },
   });
@@ -86,7 +89,7 @@ test('VSCE_PAT is valid', async (t) => {
   const { verifyVsceAuth } = await esmock('../lib/verify-vsce-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('vsce', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .resolves(),
     },
   });
@@ -103,7 +106,7 @@ test('VSCE_PAT is valid and VSCE_AZURE_CREDENTIAL=false', async (t) => {
   const { verifyVsceAuth } = await esmock('../lib/verify-vsce-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('vsce', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .resolves(),
     },
   });
@@ -136,7 +139,7 @@ test('VSCE_PAT is invalid but not empty', async (t) => {
   const { verifyVsceAuth } = await esmock('../lib/verify-vsce-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('vsce', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .rejects(),
     },
   });
@@ -156,7 +159,7 @@ test('Both VSCE_PAT and VSCE_AZURE_CREDENTIAL are set', async (t) => {
   const { verifyVsceAuth } = await esmock('../lib/verify-vsce-auth.js', {
     execa: {
       execa: stub()
-        .withArgs('vsce', ['verify-pat'], { preferLocal: true, cwd })
+        .withArgs('vsce', ['verify-pat'], { preferLocal: true, localDir, cwd })
         .rejects(),
     },
   });


### PR DESCRIPTION
- Fixes #844
- Tested in https://github.com/vscode-shellcheck/vscode-shellcheck/pull/1654