### PR TITLE
feat: use vsce Node API for packaging/publishing; update tests

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import { execa } from 'execa';
 import { readJson } from 'fs-extra/esm';
 import path from 'node:path';
 import process from 'node:process';
 import { isOvsxPublishEnabled, isTargetEnabled } from './utilities.js';
+import { createVSIX } from '@vscode/vsce/out/api.js';
 
 export async function prepare(version, packageVsix, logger, cwd) {
   if (packageVsix === false) {
@@ -33,23 +33,18 @@ export async function prepare(version, packageVsix, logger, cwd) {
 
     logger.log(`Packaging version ${version} to ${packagePath}`);
 
-    const options = [
-      'package',
+    /** @type {import('@vscode/vsce/out/package').IPackageOptions} */
+    const options = {
+      cwd,
       version,
-      '--no-git-tag-version',
-      '--out',
-      packagePath,
-    ];
+      out: packagePath,
+    };
     if (isTargetEnabled()) {
-      options.push('--target', process.env.VSCE_TARGET);
+      // @ts-ignore: target is supported in IPackageOptions
+      options.target = process.env.VSCE_TARGET;
     }
 
-    await execa('vsce', options, {
-      stdio: 'inherit',
-      preferLocal: true,
-      localDir: import.meta.dirname,
-      cwd,
-    });
+    await createVSIX(options);
 
     return packagePath;
   }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { execa } from 'execa';
 import { readJson } from 'fs-extra/esm';
 import path from 'node:path';
 import process from 'node:process';
@@ -10,6 +9,8 @@ import {
   isTargetEnabled,
   isVscePublishEnabled,
 } from './utilities.js';
+import { publish as vscePublishApi } from '@vscode/vsce/out/api.js';
+import { execa } from 'execa';
 
 export async function publish(version, packagePath, logger, cwd) {
   const { publisher, name } = await readJson(path.join(cwd, './package.json'));
@@ -43,12 +44,26 @@ export async function publish(version, packagePath, logger, cwd) {
   if (isVscePublishEnabled()) {
     logger.log(message + ' to Visual Studio Marketplace');
 
-    await execa('vsce', options, {
-      stdio: 'inherit',
-      preferLocal: true,
-      localDir: import.meta.dirname,
-      cwd,
-    });
+    /** @type {import('@vscode/vsce/out/publish').IPublishOptions} */
+    const vsceOptions = { cwd };
+    if (Array.isArray(packagePath) && packagePath.length > 0) {
+      // @ts-ignore packagePath is supported by the API
+      vsceOptions.packagePath = packagePath;
+    } else {
+      // Match previous behavior of not creating git tags
+      // @ts-ignore option is supported by API
+      vsceOptions.noGitTagVersion = true;
+      if (isTargetEnabled()) {
+        // @ts-ignore target is supported by IPublishOptions
+        vsceOptions.target = process.env.VSCE_TARGET;
+      }
+    }
+    if (isAzureCredentialEnabled()) {
+      // @ts-ignore azureCredential is supported by API
+      vsceOptions.azureCredential = true;
+    }
+
+    await vscePublishApi(vsceOptions);
     const vsceUrl = `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`;
 
     logger.log(`The new version is available at ${vsceUrl}.`);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -15,21 +15,23 @@ const cwd = process.cwd();
 
 test.beforeEach((t) => {
   t.context.stubs = {
+    vscePublishStub: stub().resolves(),
     execaStub: stub(),
   };
 });
 
 test.afterEach((t) => {
+  t.context.stubs.vscePublishStub.resetHistory();
   t.context.stubs.execaStub.resetHistory();
 });
 
 test('publish to vs marketplace with VSCE_PAT', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -50,20 +52,19 @@ test('publish to vs marketplace with VSCE_PAT', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, [
-    'vsce',
-    ['publish', version, '--no-git-tag-version'],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, noGitTagVersion: true },
   ]);
 });
 
 test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=true', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -84,21 +85,19 @@ test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=true', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  const arguments0 = execaStub.getCall(0).args;
-  t.deepEqual(arguments0, [
-    'vsce',
-    ['publish', '--packagePath', packagePath, '--azure-credential'],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, packagePath: [packagePath], azureCredential: true },
   ]);
 });
 
 test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=1', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -119,21 +118,19 @@ test('publish to vs marketplace with VSCE_AZURE_CREDENTIAL=1', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  const arguments0 = execaStub.getCall(0).args;
-  t.deepEqual(arguments0, [
-    'vsce',
-    ['publish', '--packagePath', packagePath, '--azure-credential'],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, packagePath: [packagePath], azureCredential: true },
   ]);
 });
 
 test('publish with packagePath', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -155,20 +152,19 @@ test('publish with packagePath', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, [
-    'vsce',
-    ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, packagePath: [packagePath] },
   ]);
 });
 
 test('publish with multiple packagePath', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -190,20 +186,19 @@ test('publish with multiple packagePath', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, [
-    'vsce',
-    ['publish', '--packagePath', ...packagePath],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, packagePath },
   ]);
 });
 
 test('publish with target', async (t) => {
-  const { execaStub } = t.context.stubs;
+  // execa is not used in this test
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
-    execa: {
-      execa: execaStub,
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
     },
     'fs-extra/esm': {
       readJson: stub().resolves({
@@ -226,10 +221,9 @@ test('publish with target', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, [
-    'vsce',
-    ['publish', version, '--no-git-tag-version', '--target', target],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, noGitTagVersion: true, target },
   ]);
 });
 
@@ -238,6 +232,9 @@ test('publish to OpenVSX', async (t) => {
   const publisher = 'semantic-release-vsce';
   const name = 'Semantice Release VSCE';
   const { publish } = await esmock('../lib/publish.js', {
+    '@vscode/vsce/out/api.js': {
+      publish: t.context.stubs.vscePublishStub,
+    },
     execa: {
       execa: execaStub,
     },
@@ -262,17 +259,16 @@ test('publish to OpenVSX', async (t) => {
     name: 'Visual Studio Marketplace',
     url: `https://marketplace.visualstudio.com/items?itemName=${publisher}.${name}`,
   });
-  t.deepEqual(execaStub.getCall(0).args, [
-    'vsce',
-    ['publish', '--packagePath', packagePath],
-    { stdio: 'inherit', preferLocal: true, localDir, cwd },
+  t.true(t.context.stubs.vscePublishStub.calledOnce);
+  t.deepEqual(t.context.stubs.vscePublishStub.getCall(0).args, [
+    { cwd, packagePath: [packagePath] },
   ]);
 
   // t.deepEqual(result[1], {
   //   name: 'Open VSX Registry',
   //   url: `https://open-vsx.org/extension/${publisher}/${name}/${version}`
   // });
-  t.deepEqual(execaStub.getCall(1).args, [
+  t.deepEqual(execaStub.getCall(0).args, [
     'ovsx',
     ['publish', '--packagePath', packagePath],
     { stdio: 'inherit', preferLocal: true, localDir, cwd },


### PR DESCRIPTION
Switch packaging and Visual Studio Marketplace publishing from vsce CLI invocations to the official vsce Node API. Keeps Open VSX publishing via CLI. Updates tests to mock the vsce API.
## **Changes**

1. Packaging

> - Use @vscode/vsce/out/api.js#createVSIX with IPackageOptions (cwd, version, out, optional target).

2. Publishing (VS Marketplace)

> - Use @vscode/vsce/out/api.js#publish with IPublishOptions (cwd, packagePath array or noGitTagVersion, optional target, optional azureCredential).

3. Publishing (Open VSX)

> - Remains via ovsx CLI.

2. Tests

> - Updated to mock @vscode/vsce/out/api.js and assert correct options.
> - Suite is green locally.

 ## **Rationale**

> - Avoids spawning child processes; uses stable programmatic API.
> - Prepares for more flexible option coverage (parity with CLI) and better error surfacing.

**## Backward Compatibility**
**Behavior is preserved:**

> - packageVsix and publish flows unchanged for callers.
> - Target handling with VSCE_TARGET remains.
> - VSCE_AZURE_CREDENTIAL supported via API.
> - Open VSX path unchanged.

- Types align with vsce API expectations; external plugin API remains the same.

## **Notes**

> - vsce packaging now takes IPackageOptions (replacing deprecated ICreateVSIXOptions internally).
> - vsce publishing uses IPublishOptions. Open VSX still uses CLI until we adopt its API in a follow‑up.

**## Testing**

- 59 tests passing; lints clean.
