### PR TITLE
refactor: treat empty env vars in the same way as not set

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -20,6 +20,6 @@ export function isVscePublishEnabled() {
 
 export function isTargetEnabled() {
   return (
-    'VSCE_TARGET' in process.env && process.env.VSCE_TARGET !== 'universal'
+    Boolean(process.env.VSCE_TARGET) && process.env.VSCE_TARGET !== 'universal'
   );
 }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -7,7 +7,7 @@ function environmentToBoolean(name) {
 }
 
 export function isOvsxPublishEnabled() {
-  return Boolean(process.env.OVSX_PAT);
+  return !!process.env.OVSX_PAT;
 }
 
 export function isAzureCredentialEnabled() {
@@ -15,11 +15,9 @@ export function isAzureCredentialEnabled() {
 }
 
 export function isVscePublishEnabled() {
-  return Boolean(process.env.VSCE_PAT) || isAzureCredentialEnabled();
+  return !!process.env.VSCE_PAT || isAzureCredentialEnabled();
 }
 
 export function isTargetEnabled() {
-  return (
-    Boolean(process.env.VSCE_TARGET) && process.env.VSCE_TARGET !== 'universal'
-  );
+  return !!process.env.VSCE_TARGET && process.env.VSCE_TARGET !== 'universal';
 }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -7,7 +7,7 @@ function environmentToBoolean(name) {
 }
 
 export function isOvsxPublishEnabled() {
-  return !!process.env.OVSX_PAT;
+  return Boolean(process.env.OVSX_PAT);
 }
 
 export function isAzureCredentialEnabled() {
@@ -15,7 +15,7 @@ export function isAzureCredentialEnabled() {
 }
 
 export function isVscePublishEnabled() {
-  return !!process.env.VSCE_PAT || isAzureCredentialEnabled();
+  return Boolean(process.env.VSCE_PAT) || isAzureCredentialEnabled();
 }
 
 export function isTargetEnabled() {

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -7,7 +7,7 @@ function environmentToBoolean(name) {
 }
 
 export function isOvsxPublishEnabled() {
-  return 'OVSX_PAT' in process.env;
+  return !!process.env.OVSX_PAT;
 }
 
 export function isAzureCredentialEnabled() {
@@ -15,7 +15,7 @@ export function isAzureCredentialEnabled() {
 }
 
 export function isVscePublishEnabled() {
-  return 'VSCE_PAT' in process.env || isAzureCredentialEnabled();
+  return !!process.env.VSCE_PAT || isAzureCredentialEnabled();
 }
 
 export function isTargetEnabled() {

--- a/lib/verify-target.js
+++ b/lib/verify-target.js
@@ -9,13 +9,6 @@ export async function verifyTarget() {
     return;
   }
 
-  if (!process.env.VSCE_TARGET) {
-    throw new SemanticReleaseError(
-      'Empty vsce target specified.',
-      'EINVALIDVSCETARGET',
-    );
-  }
-
   if (process.env.VSCE_TARGET !== 'universal') {
     const vscePackage = await import('@vscode/vsce/out/package.js');
     const targets = vscePackage.Targets;

--- a/lib/verify-vsce-auth.js
+++ b/lib/verify-vsce-auth.js
@@ -6,7 +6,7 @@ import process from 'node:process';
 import { isAzureCredentialEnabled } from './utilities.js';
 
 export async function verifyVsceAuth(logger, cwd) {
-  const pat = 'VSCE_PAT' in process.env && process.env.VSCE_PAT;
+  const pat = process.env.VSCE_PAT;
   const azureCredential = isAzureCredentialEnabled();
 
   if (!pat && !azureCredential) {

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -1,0 +1,61 @@
+import avaTest from 'ava';
+import { stub } from 'sinon';
+
+// Run tests serially to avoid env pollution
+const test = avaTest.serial;
+
+test('isVscePublishEnabled when empty', async (t) => {
+  stub(process, 'env').value({
+    VSCE_PAT: '',
+  });
+
+  const { isVscePublishEnabled } = await import('../lib/utilities.js');
+
+  await t.false(isVscePublishEnabled());
+});
+
+test('isVscePublishEnabled when not set', async (t) => {
+  stub(process, 'env').value({});
+
+  const { isVscePublishEnabled } = await import('../lib/utilities.js');
+
+  await t.false(isVscePublishEnabled());
+});
+
+test('isVscePublishEnabled when set', async (t) => {
+  stub(process, 'env').value({
+    VSCE_PAT: 'abc123',
+  });
+
+  const { isVscePublishEnabled } = await import('../lib/utilities.js');
+
+  await t.true(isVscePublishEnabled());
+});
+
+test('isOvsxPublishEnabled when empty', async (t) => {
+  stub(process, 'env').value({
+    OVSX_PAT: '',
+  });
+
+  const { isOvsxPublishEnabled } = await import('../lib/utilities.js');
+
+  await t.false(isOvsxPublishEnabled());
+});
+
+test('isOvsxPublishEnabled when not set', async (t) => {
+  stub(process, 'env').value({});
+
+  const { isOvsxPublishEnabled } = await import('../lib/utilities.js');
+
+  await t.false(isOvsxPublishEnabled());
+});
+
+test('isOvsxPublishEnabled when set', async (t) => {
+  stub(process, 'env').value({
+    OVSX_PAT: 'abc123',
+  });
+
+  const { isOvsxPublishEnabled } = await import('../lib/utilities.js');
+
+  await t.true(isOvsxPublishEnabled());
+});

--- a/test/verify-target.test.js
+++ b/test/verify-target.test.js
@@ -38,11 +38,7 @@ test('VSCE_TARGET is empty', async (t) => {
     VSCE_TARGET: '',
   });
 
-  await t.throwsAsync(() => verifyTarget(), {
-    instanceOf: SemanticReleaseError,
-    code: 'EINVALIDVSCETARGET',
-  });
-  t.false(vscePackage.called);
+  t.is(await verifyTarget(), undefined);
 });
 
 test('VSCE_TARGET is unsupported', async (t) => {

--- a/test/verify-target.test.js
+++ b/test/verify-target.test.js
@@ -17,16 +17,6 @@ test('VSCE_TARGET is not set', async (t) => {
   await t.notThrowsAsync(() => verifyTarget());
 });
 
-test('VSCE_TARGET is valid', async (t) => {
-  stub(process, 'env').value({
-    VSCE_TARGET: 'linux-x64',
-  });
-
-  const { verifyTarget } = await import('../lib/verify-target.js');
-
-  await t.notThrowsAsync(() => verifyTarget());
-});
-
 test('VSCE_TARGET is empty', async (t) => {
   const vscePackage = stub().returns({
     Targets: new Map(),
@@ -38,7 +28,17 @@ test('VSCE_TARGET is empty', async (t) => {
     VSCE_TARGET: '',
   });
 
-  t.is(await verifyTarget(), undefined);
+  await t.notThrowsAsync(() => verifyTarget());
+});
+
+test('VSCE_TARGET is valid', async (t) => {
+  stub(process, 'env').value({
+    VSCE_TARGET: 'linux-x64',
+  });
+
+  const { verifyTarget } = await import('../lib/verify-target.js');
+
+  await t.notThrowsAsync(() => verifyTarget());
 });
 
 test('VSCE_TARGET is unsupported', async (t) => {


### PR DESCRIPTION
I find the current handling of `OVSX_PAT`/`VSCE_PAT` a bit confusing. In many/most tools I frequently use an empty value `""` is treated as no value.

After setting up my CI/CD pipe it took quite a bit of time to figure out that the empty value set for `VSCE_PAT` (since we haven't yet added the secret) was treated as a value and not just as not set.

This PR changes proposes to change this. It is a breaking change, but it is with the goal and intention of making the tooling more intuitive. Tests has been added for the set/unset/empty cases.